### PR TITLE
Delete documents from agents

### DIFF
--- a/connectors/vector_store/db.py
+++ b/connectors/vector_store/db.py
@@ -44,8 +44,8 @@ class VectorStoreInterface():
             print(f"Error init_vector_store: {e}")
         return
 
-    def add_document(self, text, agent_id, repo, filename):
-        documents = [Document(page_content=text, metadata={"agent_id": str(agent_id), "repo": repo, "filename": filename})]
+    def add_document(self, text, agent_id, repo, full_path):
+        documents = [Document(page_content=text, metadata={"agent_id": str(agent_id), "repo": repo, "full_path": full_path})]
         text_splitter = RecursiveCharacterTextSplitter(
             chunk_size=self.vector_chunk_size,
             chunk_overlap=self.vector_chunk_overlap,

--- a/connectors/vector_store/db.py
+++ b/connectors/vector_store/db.py
@@ -65,7 +65,7 @@ class VectorStoreInterface():
         return
 
     def search(self, query, agent_id):
-        docs_with_score = self.store.max_marginal_relevance_search_with_score(query=query, filter={"agent_id": agent_id}, k=4)
+        docs_with_score = self.store.max_marginal_relevance_search_with_score(query=query, filter={"agent_id": str(agent_id)}, k=4)
         return docs_with_score      # list(int, Document(page_content, metadata))
     
     def delete_documents(self, ids):

--- a/connectors/vector_store/db.py
+++ b/connectors/vector_store/db.py
@@ -44,8 +44,8 @@ class VectorStoreInterface():
             print(f"Error init_vector_store: {e}")
         return
 
-    def add_document(self, text, agent_id, repo, path, filename):
-        documents = [Document(page_content=text, metadata={"agent_id": str(agent_id), "repo": repo, "path": path, "filename": filename})]
+    def add_document(self, text, agent_id, repo, filename):
+        documents = [Document(page_content=text, metadata={"agent_id": str(agent_id), "repo": repo, "filename": filename})]
         text_splitter = RecursiveCharacterTextSplitter(
             chunk_size=self.vector_chunk_size,
             chunk_overlap=self.vector_chunk_overlap,

--- a/connectors/vector_store/db.py
+++ b/connectors/vector_store/db.py
@@ -44,8 +44,8 @@ class VectorStoreInterface():
             print(f"Error init_vector_store: {e}")
         return
 
-    def add_document(self, text, agent_id, path, filename):
-        documents = [Document(page_content=text, metadata={"agent_id": str(agent_id), "path": path, "filename": filename})]
+    def add_document(self, text, agent_id, repo, path, filename):
+        documents = [Document(page_content=text, metadata={"agent_id": str(agent_id), "repo": repo, "path": path, "filename": filename})]
         text_splitter = RecursiveCharacterTextSplitter(
             chunk_size=self.vector_chunk_size,
             chunk_overlap=self.vector_chunk_overlap,

--- a/connectors/vector_store/db.py
+++ b/connectors/vector_store/db.py
@@ -1,3 +1,4 @@
+import uuid
 from flask_sqlalchemy import SQLAlchemy
 from langchain_core.documents import Document
 from langchain_openai import OpenAIEmbeddings
@@ -43,8 +44,8 @@ class VectorStoreInterface():
             print(f"Error init_vector_store: {e}")
         return
 
-    def add_document(self, text, agent_id, filename):
-        documents = [Document(page_content=text, metadata={"agent_id": agent_id, "filename": filename})]
+    def add_document(self, text, agent_id, path, filename):
+        documents = [Document(page_content=text, metadata={"agent_id": str(agent_id), "path": path, "filename": filename})]
         text_splitter = RecursiveCharacterTextSplitter(
             chunk_size=self.vector_chunk_size,
             chunk_overlap=self.vector_chunk_overlap,
@@ -66,6 +67,9 @@ class VectorStoreInterface():
     def search(self, query, agent_id):
         docs_with_score = self.store.max_marginal_relevance_search_with_score(query=query, filter={"agent_id": agent_id}, k=4)
         return docs_with_score      # list(int, Document(page_content, metadata))
+    
+    def delete_documents(self, ids):
+        self.store.delete(ids)
 
 
 vector_interface = VectorStoreInterface()

--- a/connectors/vector_store/db.py
+++ b/connectors/vector_store/db.py
@@ -44,8 +44,8 @@ class VectorStoreInterface():
             print(f"Error init_vector_store: {e}")
         return
 
-    def add_document(self, text, agent_id, repo, full_path):
-        documents = [Document(page_content=text, metadata={"agent_id": str(agent_id), "repo": repo, "full_path": full_path})]
+    def add_document(self, text, agent_id, source, full_path):
+        documents = [Document(page_content=text, metadata={"agent_id": str(agent_id), "source": source, "full_path": full_path})]
         text_splitter = RecursiveCharacterTextSplitter(
             chunk_size=self.vector_chunk_size,
             chunk_overlap=self.vector_chunk_overlap,

--- a/file_upload_cli.py
+++ b/file_upload_cli.py
@@ -14,11 +14,11 @@ def upload_files(repo, directory_path, agent_id):
 
     for i in range(num_batches):
         batch_files = files[i * batch_size: (i+1) * batch_size]
-        files_to_upload = [('file', (os.path.basename(file_path), open(file_path, 'rb'), 'text/plain')) for file_path in batch_files]
+        files_to_upload = [('file', (file_path, open(file_path, 'rb'), 'text/plain')) for file_path in batch_files]
 
         # print(files_to_upload)
         url = f'http://localhost:3000/agents/{agent_id}/document_upload'
-        response = requests.post(url, files=files_to_upload, data={"repo": repo, "path": directory_path})
+        response = requests.post(url, files=files_to_upload, data={"repo": repo})
 
         if response.status_code == 200:
             print(f"Batch {i+1}/{num_batches} uploaded successfully.")

--- a/file_upload_cli.py
+++ b/file_upload_cli.py
@@ -4,7 +4,7 @@ import os
 import requests
 
 
-def upload_files(repo, directory_path, agent_id):
+def upload_files(source, directory_path, agent_id):
     files = glob.glob(os.path.join(directory_path, '**', '*.rst'), recursive=True)
     files.extend(glob.glob(os.path.join(directory_path, '**', '*.md'), recursive=True))
 
@@ -18,7 +18,7 @@ def upload_files(repo, directory_path, agent_id):
 
         # print(files_to_upload)
         url = f'http://localhost:3000/agents/{agent_id}/document_upload'
-        response = requests.post(url, files=files_to_upload, data={"repo": repo})
+        response = requests.post(url, files=files_to_upload, data={"source": source})
 
         if response.status_code == 200:
             print(f"Batch {i+1}/{num_batches} uploaded successfully.")
@@ -30,10 +30,10 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser(description="Upload .rst and .md files to a tangerine agent.")
-    parser.add_argument("repo", type=str, help="Name of repository.")
+    parser.add_argument("source", type=str, help="Name of document source.")
     parser.add_argument("directory_path", type=str, help="Path to the directory containing .rst and .md files.")
     parser.add_argument("agent_id", type=str, help="Agen ID of the tangerine agent.")
 
     args = parser.parse_args()
     
-    upload_files(args.repo, args.directory_path, args.agent_id)
+    upload_files(args.source, args.directory_path, args.agent_id)

--- a/file_upload_cli.py
+++ b/file_upload_cli.py
@@ -4,7 +4,7 @@ import os
 import requests
 
 
-def upload_files(directory_path, agent_id):
+def upload_files(repo, directory_path, agent_id):
     files = glob.glob(os.path.join(directory_path, '**', '*.rst'), recursive=True)
     files.extend(glob.glob(os.path.join(directory_path, '**', '*.md'), recursive=True))
 
@@ -18,7 +18,7 @@ def upload_files(directory_path, agent_id):
 
         # print(files_to_upload)
         url = f'http://localhost:3000/agents/{agent_id}/document_upload'
-        response = requests.post(url, files=files_to_upload, data={"path": directory_path})
+        response = requests.post(url, files=files_to_upload, data={"repo": repo, "path": directory_path})
 
         if response.status_code == 200:
             print(f"Batch {i+1}/{num_batches} uploaded successfully.")
@@ -30,9 +30,10 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser(description="Upload .rst and .md files to a tangerine agent.")
+    parser.add_argument("repo", type=str, help="Name of repository.")
     parser.add_argument("directory_path", type=str, help="Path to the directory containing .rst and .md files.")
     parser.add_argument("agent_id", type=str, help="Agen ID of the tangerine agent.")
 
     args = parser.parse_args()
     
-    upload_files(args.directory_path, args.agent_id)
+    upload_files(args.repo, args.directory_path, args.agent_id)

--- a/file_upload_cli.py
+++ b/file_upload_cli.py
@@ -18,7 +18,7 @@ def upload_files(directory_path, agent_id):
 
         # print(files_to_upload)
         url = f'http://localhost:3000/agents/{agent_id}/document_upload'
-        response = requests.post(url, files=files_to_upload)
+        response = requests.post(url, files=files_to_upload, data={"path": directory_path})
 
         if response.status_code == 200:
             print(f"Batch {i+1}/{num_batches} uploaded successfully.")

--- a/resources/agent.py
+++ b/resources/agent.py
@@ -103,6 +103,9 @@ class AgentApi(Resource):
         # TODO: delete agent documents from vector store
 
 class AgentDocUpload(Resource):
+    def get_file_id(self, repo, path, filename):
+        return f"{repo}:{path}{filename}"
+
     def post(self, id):
         id = int(id)
         agent = Agents.query.get(id)
@@ -120,7 +123,7 @@ class AgentDocUpload(Resource):
         file_contents=[]
         for file in files:
             filename = file.filename
-            file_id = f"{repo}:{path}{file.filename}"
+            file_id = self.get_file_id(repo, path, filename)
             if not any([file_id.endswith(filetype) for filetype in [".txt", ".pdf", ".md", ".rst"]]):
                 return {'message': 'Unsupported file type uploaded'}, 400
 
@@ -164,7 +167,7 @@ class AgentDocUpload(Resource):
         # delete documents from agent
         id = int(id)
         agent = Agents.query.get(id)
-        file_id = f"{repo}:{path}{filename}"
+        file_id = self.get_file_id(repo, path, filename)
         new_filenames = [file for file in agent.filenames.copy() if file != file_id]
         agent.filenames = new_filenames
         db.session.commit()


### PR DESCRIPTION
This will allow us to delete files from agents and their docs in the vector store. This is achieved by adding metadata to our documents.

I updated the `file_upload_cli` so that the repo is passed in and the filename is the whole path. Having the whole path in there prevents things from getting deleted when they shouldn't (i.e. the bonfire has two README.md files). It doesn't _look_ nice in the tables but it gets the job done.

For the vector store:
  The metadata is stored in the table `langchain_pg_embedding` in the column `cmetadata`. The metadata itself is a string in a json object format like `{"repo": repo, "agent_id": id, "filename": filename}`. The `id` field is a uuid generated by the vector store automatically and used to delete the documents.

Example file upload:
`python file_upload_cli.py <repo> <path> <agent_id>`

`python file_upload_cli.py bonfire ../bonfire/ 1`

Example file deletion:
`curl -X DELETE localhost:5000/agents/<agent_id>/document_upload -H "Content-Type: application/json" --data '{"full_path":"<path+filename>","repo":"<repo>"}`

`curl -X DELETE localhost:5000/agents/1/document_upload -H "Content-Type: application/json" --data '{"full_path":"../bonfire/cicd/README.md","repo":"bonfire"}'`