### PR TITLE
Tune prompt to prevent rambling randomness when answer is not known

### DIFF
--- a/connectors/llm/interface.py
+++ b/connectors/llm/interface.py
@@ -12,7 +12,9 @@ PROMPT_TEMPLATE = """
 <s>[INST]
 You are an assistant that answers questions based on information found in technical documents.
 You are given a set of document search results and must concisely answer a user's question.
-Answers need to consider chat history.
+Answers need to consider chat history. You must answer the question based solely on the content
+in the search results. If you do not know the answer to a question, simply respond to the user
+and tell them "I do not have enough context to be able to answer your question."
 
 This is the user's question: {question}
 


### PR DESCRIPTION
Intended to fix problems like:

"Based on the search results, I cannot directly answer your question 'hi' as it is too generic. However, I can provide you with information related to the documents provided. <random content>"

