### PR TITLE
Add temperature as a configurable option

### DIFF
--- a/connectors/config.py
+++ b/connectors/config.py
@@ -8,9 +8,11 @@ DB_PORT = os.getenv("DB_PORT", "5432")
 DB_URI = f"postgresql+psycopg://{DB_USERNAME}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
 VECTOR_COLLECTION_NAME = os.getenv("VECTOR_COLLECTION_NAME", "collection")
 
+
 LLM_BASE_URL = os.getenv("LLM_BASE_URL", "http://localhost:11434/v1")
 LLM_API_KEY = os.getenv("LLM_API_KEY", "EMPTY")
 LLM_MODEL_NAME = os.getenv("LLM_MODEL_NAME", "mistral")
+LLM_TEMPERATURE = float(os.getenv("LLM_TEMPERATURE", 0.7))
 
 EMBED_BASE_URL = os.getenv("EMBED_BASE_URL", "http://localhost:11434/v1")
 EMBED_API_KEY = os.getenv("EMBED_API_KEY", "EMPTY")

--- a/connectors/llm/interface.py
+++ b/connectors/llm/interface.py
@@ -75,6 +75,7 @@ class LLMInterface:
             model=cfg.LLM_MODEL_NAME,
             openai_api_base=cfg.LLM_BASE_URL,
             openai_api_key=cfg.LLM_API_KEY,
+            temperature=cfg.LLM_TEMPERATURE,
         )
 
         chain = prompt | model | StrOutputParser()

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -359,3 +359,5 @@ parameters:
     value: mistralai/Mistral-7B-Instruct-v0.2
   - name: EMBED_MODEL_NAME
     value: Snowflake/snowflake-arctic-embed-m-long
+  - name: LLM_TEMPERATURE
+    value: "0.3"


### PR DESCRIPTION
This patch adds a new config env var `LLM_TEMPERATURE` that is used to configure the temperature for the model. The default is set to `0.7` which is the default for langchain openapi models. Finally we set temperature to `0.3` in the deploy template.