### PR TITLE
Delete files in a managed agent if prefix is no longer configured

### DIFF
--- a/connectors/s3/sync.py
+++ b/connectors/s3/sync.py
@@ -181,6 +181,12 @@ def compare_files(agent_config: AgentConfig, agent: Agent):
             agent_objects_to_delete.append(agent_object)
             num_to_delete += 1
 
+        # check if an entire prefix is no longer defined in the agent config
+        if not any([full_path.startswith(prefix) for prefix in prefixes]):
+            log.debug("%s uses prefix not found in agent config, will remove file", full_path)
+            agent_objects_to_delete.append(agent_object)
+            num_to_delete += 1
+
     # check if there's a new remote file to add
     for key, s3_object in s3_objects_by_key.items():
         if key not in agent_objects_by_path:

--- a/connectors/s3/sync.py
+++ b/connectors/s3/sync.py
@@ -164,8 +164,21 @@ def compare_files(agent_config: AgentConfig, agent: Agent):
     for agent_object in agent_objects:
         full_path = agent_object["full_path"]
 
+        # check if the entire prefix is no longer defined in the agent config
+        if not any([full_path.startswith(prefix) for prefix in prefixes]):
+            log.debug("%s uses prefix not found in agent config, will remove file", full_path)
+            agent_objects_to_delete.append(agent_object)
+            num_to_delete += 1
+
+        # check if remote file has been removed
+        elif full_path not in s3_objects_by_key:
+            # stored file is not present in s3, mark for deletion
+            log.debug("%s no longer present in s3, will remove file", full_path)
+            agent_objects_to_delete.append(agent_object)
+            num_to_delete += 1
+
         # check if remote file has been updated
-        if full_path in s3_objects_by_key:
+        elif full_path in s3_objects_by_key:
             hash = agent_object.get("hash")
             etag = s3_objects_by_key[full_path]["ETag"]
             if hash != etag:
@@ -173,19 +186,6 @@ def compare_files(agent_config: AgentConfig, agent: Agent):
                 s3_objects_to_insert.append(s3_objects_by_key[full_path])
                 agent_objects_to_delete.append(agent_object)
                 num_to_update += 1
-
-        # check if remote file has been removed
-        if full_path not in s3_objects_by_key:
-            # stored file is not present in s3, mark for deletion
-            log.debug("%s no longer present in s3, will remove file", full_path)
-            agent_objects_to_delete.append(agent_object)
-            num_to_delete += 1
-
-        # check if an entire prefix is no longer defined in the agent config
-        if not any([full_path.startswith(prefix) for prefix in prefixes]):
-            log.debug("%s uses prefix not found in agent config, will remove file", full_path)
-            agent_objects_to_delete.append(agent_object)
-            num_to_delete += 1
 
     # check if there's a new remote file to add
     for key, s3_object in s3_objects_by_key.items():


### PR DESCRIPTION
If the s3 prefix that an agent is configured to use is completely removed from the agent config, we should delete any files in the vector DB associated with the old prefix. This only applies to a "managed agent" i.e. one that the s3sync is explicitly instructed to configure via s3sync.yaml