### PR TITLE
Better error handling during doc sync

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 
 import click
 from flask import Flask, current_app
@@ -46,4 +47,5 @@ def create_app():
 @with_appcontext
 def s3sync():
     current_app.logger.info("running s3sync")
-    connectors.s3.sync.run()
+    exit_code = connectors.s3.sync.run()
+    sys.exit(exit_code)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     container_name: tangerine-backend
     build:
       context: .
-      dockerfile: Dockerfile.centos
+      dockerfile: Dockerfile
     ports:
       - "5000:5000"
     environment:


### PR DESCRIPTION
Currently if we hit an error while download or embedding a file, the whole sync process aborts

Instead, we will keep a running count of errors encountered during the sync an keep trying to proceed.

At the end, if there were any errors detected while sync'ing an agent, we will log the count and exit with error code 1