### PR TITLE
Convert markdown tables into condensed format, apply same processing logic to all md content

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -24,6 +24,7 @@ mdformat = "*"
 boto3 = "*"
 pydantic = "*"
 jinja2 = "*"
+pytablereader = {extras = ["md"], version = "*"}
 
 [dev-packages]
 black = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9539fd345054e7ec088d176a1f1dc3d35dac64fb9c01ea6676bad5c4d1783972"
+            "sha256": "4adb1eb996e8c71982ab2e976590f7fc8418de0cee1dcade9ccb1ba92135b066"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -39,6 +39,14 @@
             "markers": "python_version >= '3.9'",
             "version": "==4.6.2.post1"
         },
+        "attrs": {
+            "hashes": [
+                "sha256:5cfb1b9148b5b086569baec03f20d7b6bf3bcacc9a42bebf87ffaaca362f6346",
+                "sha256:81921eb96de3191c8258c199618104dd27ac608d9366f5e35d011eae1867ede2"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==24.2.0"
+        },
         "beautifulsoup4": {
             "hashes": [
                 "sha256:74e3d1928edc070d21748185c46e3fb33490f22f52a3addee9aee0f4f7781051",
@@ -57,19 +65,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:09a610f8cf4d3c22d4ca69c1f89079e3a1c82805ce94fa0eb4ecdd4d2ba6c4bc",
-                "sha256:c392b9168b65e9c23483eaccb5b68d1f960232d7f967a1e00a045ba065ce050d"
+                "sha256:20945912130cca1505f45819cd9b7183a0e376e91a1221a0b1f50c80d35fd7e2",
+                "sha256:40db86c7732a310b282f595251995ecafcbd62009a57e47a22683862e570cc7a"
             ],
             "index": "pypi",
-            "version": "==1.35.66"
+            "version": "==1.35.69"
         },
         "botocore": {
             "hashes": [
-                "sha256:51f43220315f384959f02ea3266740db4d421592dd87576c18824e424b349fdb",
-                "sha256:d0683e9c18bb6852f768da268086c3749d925332a664db0dd1459cfa7e96e475"
+                "sha256:cad8d9305f873404eee4b197d84e60a40975d43cbe1ab63abe893420ddfe6e3c",
+                "sha256:f9f23dd76fb247d9b0e8d411d2995e6f847fc451c026f1e58e300f815b0b36eb"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.35.66"
+            "version": "==1.35.69"
         },
         "bs4": {
             "hashes": [
@@ -86,6 +94,14 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==2024.8.30"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7",
+                "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==5.2.0"
         },
         "charset-normalizer": {
             "hashes": [
@@ -205,6 +221,14 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==8.1.7"
+        },
+        "dataproperty": {
+            "hashes": [
+                "sha256:0b8b07d4fb6453fcf975b53d35dea41f3cfd69c9d79b5010c3cf224ff0407a7a",
+                "sha256:723e5729fa6e885e127a771a983ee1e0e34bb141aca4ffe1f0bfa7cde34650a4"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.0.1"
         },
         "distro": {
             "hashes": [
@@ -491,21 +515,37 @@
             "markers": "python_version >= '3.7'",
             "version": "==3.0.0"
         },
+        "jsonschema": {
+            "hashes": [
+                "sha256:d71497fef26351a33265337fa77ffeb82423f3ea21283cd9467bb03999266bc4",
+                "sha256:fbadb6f8b144a8f8cf9f0b89ba94501d143e50411a1278633f56a7acf7fd5566"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==4.23.0"
+        },
+        "jsonschema-specifications": {
+            "hashes": [
+                "sha256:0f38b83639958ce1152d02a7f062902c41c8fd20d558b0c34344292d417ae272",
+                "sha256:a09a0680616357d9a0ecf05c12ad234479f549239d0f5b55f3deea67475da9bf"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==2024.10.1"
+        },
         "langchain-core": {
             "hashes": [
-                "sha256:126d9e8cadb2a5b8d1793a228c0783a3b608e36064d5a2ef1a4d38d07a344523",
-                "sha256:562b7cc3c15dfaa9270cb1496990c1f3b3e0b660c4d6a3236d7f693346f2a96c"
+                "sha256:561b52b258ffa50a9fb11d7a1940ebfd915654d1ec95b35e81dfd5ee84143411",
+                "sha256:7e723dff80946a1198976c6876fea8326dc82566ef9bcb5f8d9188f738733665"
             ],
             "index": "pypi",
-            "version": "==0.3.19"
+            "version": "==0.3.21"
         },
         "langchain-openai": {
             "hashes": [
-                "sha256:2723015e56879f9e5edfcb175fdbec6c296c1b3bf65caad28579ce9c4d1bd652",
-                "sha256:38a0f2004f17cdad622d46d4dcfb92d75adbf51909dadc76d0360dd94b0d4f70"
+                "sha256:878200a84d80353fc47720631bf591157e56b6a3923e5f7b13c7f61c82999b50",
+                "sha256:b06a14d99ab81343f23ced83de21fc1cfcd79c9fb96fdbd9070ad018038c5602"
             ],
             "index": "pypi",
-            "version": "==0.2.9"
+            "version": "==0.2.10"
         },
         "langchain-postgres": {
             "hashes": [
@@ -525,11 +565,11 @@
         },
         "langsmith": {
             "hashes": [
-                "sha256:08ffb975bff2e82fc6f5428837c64c074ea25102d08a25e256361a80812c6100",
-                "sha256:b621f358d5a33441d7b5e7264c376bf4ea82bfc62d7e41aafc0f8094e3bd6369"
+                "sha256:9d062222f1a32c9b047dab0149b24958f988989cd8d4a5f9139ff959a51e59d8",
+                "sha256:ead8b0b9d5b6cd3ac42937ec48bdf09d4afe7ca1bba22dc05eb65591a18106f8"
             ],
             "markers": "python_version < '4.0' and python_full_version >= '3.8.1'",
-            "version": "==0.1.144"
+            "version": "==0.1.146"
         },
         "lxml": {
             "hashes": [
@@ -675,6 +715,13 @@
             "index": "pypi",
             "version": "==5.3.0"
         },
+        "markdown": {
+            "hashes": [
+                "sha256:2ae2471477cfd02dbbf038d5d9bc226d40def84b4fe2986e49b59b6b472bbed2",
+                "sha256:7eb6df5690b81a1d7942992c97fad2938e956e79df20cbc6186e9c3a77b1c803"
+            ],
+            "version": "==3.7"
+        },
         "markdown-it-py": {
             "hashes": [
                 "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1",
@@ -750,6 +797,14 @@
             "markers": "python_version >= '3.9'",
             "version": "==3.0.2"
         },
+        "mbstrdecoder": {
+            "hashes": [
+                "sha256:d66c1ed3f2dc4e7c5d87cd44a75be10bc5af4250f95b38bbaedd7851308ce938",
+                "sha256:dcfd2c759322eb44fe193a9e0b1b86c5b87f3ec5ea8e1bb43b3e9ae423f1e8fe"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.1.3"
+        },
         "mdformat": {
             "hashes": [
                 "sha256:5c360992adc118cf1479cbbe92bb3bd66dcd7f1a5a3a2ad6675915622c678cf1",
@@ -810,75 +865,92 @@
         },
         "openai": {
             "hashes": [
-                "sha256:446e08918f8dd70d8723274be860404c8c7cc46b91b93bbc0ef051f57eb503c1",
-                "sha256:6c0975ac8540fe639d12b4ff5a8e0bf1424c844c4a4251148f59f06c4b2bd5db"
+                "sha256:471324321e7739214f16a544e801947a046d3c5d516fae8719a317234e4968d3",
+                "sha256:d10d96a4f9dc5f05d38dea389119ec8dcd24bc9698293c8357253c601b4a77a5"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.55.0"
+            "version": "==1.55.1"
         },
         "orjson": {
             "hashes": [
-                "sha256:03246774131701de8e7059b2e382597da43144a9a7400f178b2a32feafc54bd5",
-                "sha256:0efabbf839388a1dab5b72b5d3baedbd6039ac83f3b55736eb9934ea5494d258",
-                "sha256:10f416b2a017c8bd17f325fb9dee1fb5cdd7a54e814284896b7c3f2763faa017",
-                "sha256:1444f9cb7c14055d595de1036f74ecd6ce15f04a715e73f33bb6326c9cef01b6",
-                "sha256:1789d9db7968d805f3d94aae2c25d04014aae3a2fa65b1443117cd462c6da647",
-                "sha256:19b3763e8bbf8ad797df6b6b5e0fc7c843ec2e2fc0621398534e0c6400098f87",
-                "sha256:1a1222ffcee8a09476bbdd5d4f6f33d06d0d6642df2a3d78b7a195ca880d669b",
-                "sha256:1be83a13312e5e58d633580c5eb8d0495ae61f180da2722f20562974188af205",
-                "sha256:1f39728c7f7d766f1f5a769ce4d54b5aaa4c3f92d5b84817053cc9995b977acc",
-                "sha256:360a4e2c0943da7c21505e47cf6bd725588962ff1d739b99b14e2f7f3545ba51",
-                "sha256:461311b693d3d0a060439aa669c74f3603264d4e7a08faa68c47ae5a863f352d",
-                "sha256:496e2cb45de21c369079ef2d662670a4892c81573bcc143c4205cae98282ba97",
-                "sha256:4bfb30c891b530f3f80e801e3ad82ef150b964e5c38e1fb8482441c69c35c61c",
-                "sha256:4d83f87582d223e54efb2242a79547611ba4ebae3af8bae1e80fa9a0af83bb7f",
-                "sha256:4eed32f33a0ea6ef36ccc1d37f8d17f28a1d6e8eefae5928f76aff8f1df85e67",
-                "sha256:51f3382415747e0dbda9dade6f1e1a01a9d37f630d8c9049a8ed0e385b7a90c0",
-                "sha256:52ca832f17d86a78cbab86cdc25f8c13756ebe182b6fc1a97d534051c18a08de",
-                "sha256:52e5834d7d6e58a36846e059d00559cb9ed20410664f3ad156cd2cc239a11230",
-                "sha256:5576b1e5a53a5ba8f8df81872bb0878a112b3ebb1d392155f00f54dd86c83ff6",
-                "sha256:63fc9d5fe1d4e8868f6aae547a7b8ba0a2e592929245fff61d633f4caccdcdd6",
-                "sha256:655a493bac606655db9a47fe94d3d84fc7f3ad766d894197c94ccf0c5408e7d3",
-                "sha256:65cd3e3bb4fbb4eddc3c1e8dce10dc0b73e808fcb875f9fab40c81903dd9323e",
-                "sha256:677f23e32491520eebb19c99bb34675daf5410c449c13416f7f0d93e2cf5f981",
-                "sha256:6dade64687f2bd7c090281652fe18f1151292d567a9302b34c2dbb92a3872f1f",
-                "sha256:6f67c570602300c4befbda12d153113b8974a3340fdcf3d6de095ede86c06d92",
-                "sha256:705f03cee0cb797256d54de6695ef219e5bc8c8120b6654dd460848d57a9af3d",
-                "sha256:77b0fed6f209d76c1c39f032a70df2d7acf24b1812ca3e6078fd04e8972685a3",
-                "sha256:7dfa8db55c9792d53c5952900c6a919cfa377b4f4534c7a786484a6a4a350c19",
-                "sha256:80c00d4acded0c51c98754fe8218cb49cb854f0f7eb39ea4641b7f71732d2cb7",
-                "sha256:80df27dd8697242b904f4ea54820e2d98d3f51f91e97e358fc13359721233e4b",
-                "sha256:82f07c550a6ccd2b9290849b22316a609023ed851a87ea888c0456485a7d196a",
-                "sha256:86b9dd983857970c29e4c71bb3e95ff085c07d3e83e7c46ebe959bac07ebd80b",
-                "sha256:8b5759063a6c940a69c728ea70d7c33583991c6982915a839c8da5f957e0103a",
-                "sha256:96ed1de70fcb15d5fed529a656df29f768187628727ee2788344e8a51e1c1350",
-                "sha256:9fd0ad1c129bc9beb1154c2655f177620b5beaf9a11e0d10bac63ef3fce96950",
-                "sha256:a11225d7b30468dcb099498296ffac36b4673a8398ca30fdaec1e6c20df6aa55",
-                "sha256:a2fc947e5350fdce548bfc94f434e8760d5cafa97fb9c495d2fef6757aa02ec0",
-                "sha256:a3f29634260708c200c4fe148e42b4aae97d7b9fee417fbdd74f8cfc265f15b0",
-                "sha256:afacfd1ab81f46dedd7f6001b6d4e8de23396e4884cd3c3436bd05defb1a6446",
-                "sha256:b592597fe551d518f42c5a2eb07422eb475aa8cfdc8c51e6da7054b836b26782",
-                "sha256:b7fcfc6f7ca046383fb954ba528587e0f9336828b568282b27579c49f8e16aad",
-                "sha256:b9546b278c9fb5d45380f4809e11b4dd9844ca7aaf1134024503e134ed226161",
-                "sha256:bc274ac261cc69260913b2d1610760e55d3c0801bb3457ba7b9004420b6b4270",
-                "sha256:bd9a187742d3ead9df2e49240234d728c67c356516cf4db018833a86f20ec18c",
-                "sha256:c46294faa4e4d0eb73ab68f1a794d2cbf7bab33b1dda2ac2959ffb7c61591899",
-                "sha256:c95f2ecafe709b4e5c733b5e2768ac569bed308623c85806c395d9cca00e08af",
-                "sha256:cb4d0bea56bba596723d73f074c420aec3b2e5d7d30698bc56e6048066bd560c",
-                "sha256:cdec57fe3b4bdebcc08a946db3365630332dbe575125ff3d80a3272ebd0ddafe",
-                "sha256:d496c74fc2b61341e3cefda7eec21b7854c5f672ee350bc55d9a4997a8a95204",
-                "sha256:d4a62c49c506d4d73f59514986cadebb7e8d186ad510c518f439176cf8d5359d",
-                "sha256:df8c677df2f9f385fcc85ab859704045fa88d4668bc9991a527c86e710392bec",
-                "sha256:dfbb2d460a855c9744bbc8e36f9c3a997c4b27d842f3d5559ed54326e6911f9b",
-                "sha256:e2f3b7c5803138e67028dde33450e054c87e0703afbe730c105f1fcd873496d5",
-                "sha256:e35b6d730de6384d5b2dab5fd23f0d76fae8bbc8c353c2f78210aa5fa4beb3ef",
-                "sha256:f1eec3421a558ff7a9b010a6c7effcfa0ade65327a71bb9b02a1c3b77a247284",
-                "sha256:f35a1b9f50a219f470e0e497ca30b285c9f34948d3c8160d5ad3a755d9299433",
-                "sha256:f4c57ea78a753812f528178aa2f1c57da633754c91d2124cb28991dab4c79a54",
-                "sha256:f91d9eb554310472bd09f5347950b24442600594c2edc1421403d7610a0998fd"
+                "sha256:0000758ae7c7853e0a4a6063f534c61656ebff644391e1f81698c1b2d2fc8cd2",
+                "sha256:038d42c7bc0606443459b8fe2d1f121db474c49067d8d14c6a075bbea8bf14dd",
+                "sha256:03b553c02ab39bed249bedd4abe37b2118324d1674e639b33fab3d1dafdf4d79",
+                "sha256:0a78bbda3aea0f9f079057ee1ee8a1ecf790d4f1af88dd67493c6b8ee52506ff",
+                "sha256:0b32652eaa4a7539f6f04abc6243619c56f8530c53bf9b023e1269df5f7816dd",
+                "sha256:0eee4c2c5bfb5c1b47a5db80d2ac7aaa7e938956ae88089f098aff2c0f35d5d8",
+                "sha256:16135ccca03445f37921fa4b585cff9a58aa8d81ebcb27622e69bfadd220b32c",
+                "sha256:165c89b53ef03ce0d7c59ca5c82fa65fe13ddf52eeb22e859e58c237d4e33b9b",
+                "sha256:1da1ef0113a2be19bb6c557fb0ec2d79c92ebd2fed4cfb1b26bab93f021fb885",
+                "sha256:229994d0c376d5bdc91d92b3c9e6be2f1fbabd4cc1b59daae1443a46ee5e9825",
+                "sha256:22a51ae77680c5c4652ebc63a83d5255ac7d65582891d9424b566fb3b5375ee9",
+                "sha256:24ce85f7100160936bc2116c09d1a8492639418633119a2224114f67f63a4559",
+                "sha256:2b57cbb4031153db37b41622eac67329c7810e5f480fda4cfd30542186f006ae",
+                "sha256:2d879c81172d583e34153d524fcba5d4adafbab8349a7b9f16ae511c2cee8708",
+                "sha256:35d3081bbe8b86587eb5c98a73b97f13d8f9fea685cf91a579beddacc0d10566",
+                "sha256:362d204ad4b0b8724cf370d0cd917bb2dc913c394030da748a3bb632445ce7c4",
+                "sha256:36b4aa31e0f6a1aeeb6f8377769ca5d125db000f05c20e54163aef1d3fe8e833",
+                "sha256:3f250ce7727b0b2682f834a3facff88e310f52f07a5dcfd852d99637d386e79e",
+                "sha256:43509843990439b05f848539d6f6198d4ac86ff01dd024b2f9a795c0daeeab60",
+                "sha256:440d9a337ac8c199ff8251e100c62e9488924c92852362cd27af0e67308c16ef",
+                "sha256:475661bf249fd7907d9b0a2a2421b4e684355a77ceef85b8352439a9163418c3",
+                "sha256:47962841b2a8aa9a258b377f5188db31ba49af47d4003a32f55d6f8b19006543",
+                "sha256:53206d72eb656ca5ac7d3a7141e83c5bbd3ac30d5eccfe019409177a57634b0d",
+                "sha256:5472be7dc3269b4b52acba1433dac239215366f89dc1d8d0e64029abac4e714e",
+                "sha256:5535163054d6cbf2796f93e4f0dbc800f61914c0e3c4ed8499cf6ece22b4a3da",
+                "sha256:5dee91b8dfd54557c1a1596eb90bcd47dbcd26b0baaed919e6861f076583e9da",
+                "sha256:5f29c5d282bb2d577c2a6bbde88d8fdcc4919c593f806aac50133f01b733846e",
+                "sha256:6334730e2532e77b6054e87ca84f3072bee308a45a452ea0bffbbbc40a67e296",
+                "sha256:6402ebb74a14ef96f94a868569f5dccf70d791de49feb73180eb3c6fda2ade56",
+                "sha256:703a2fb35a06cdd45adf5d733cf613cbc0cb3ae57643472b16bc22d325b5fb6c",
+                "sha256:7319cda750fca96ae5973efb31b17d97a5c5225ae0bc79bf5bf84df9e1ec2ab6",
+                "sha256:73c23a6e90383884068bc2dba83d5222c9fcc3b99a0ed2411d38150734236755",
+                "sha256:74d5ca5a255bf20b8def6a2b96b1e18ad37b4a122d59b154c458ee9494377f80",
+                "sha256:750f8b27259d3409eda8350c2919a58b0cfcd2054ddc1bd317a643afc646ef23",
+                "sha256:77a4e1cfb72de6f905bdff061172adfb3caf7a4578ebf481d8f0530879476c07",
+                "sha256:7a3273e99f367f137d5b3fecb5e9f45bcdbfac2a8b2f32fbc72129bbd48789c2",
+                "sha256:7d69af5b54617a5fac5c8e5ed0859eb798e2ce8913262eb522590239db6c6763",
+                "sha256:7ed119ea7d2953365724a7059231a44830eb6bbb0cfead33fcbc562f5fd8f935",
+                "sha256:802a3935f45605c66fb4a586488a38af63cb37aaad1c1d94c982c40dcc452e85",
+                "sha256:855c0833999ed5dc62f64552db26f9be767434917d8348d77bacaab84f787d7b",
+                "sha256:87251dc1fb2b9e5ab91ce65d8f4caf21910d99ba8fb24b49fd0c118b2362d509",
+                "sha256:888442dcee99fd1e5bd37a4abb94930915ca6af4db50e23e746cdf4d1e63db13",
+                "sha256:897830244e2320f6184699f598df7fb9db9f5087d6f3f03666ae89d607e4f8ed",
+                "sha256:8a76ba5fc8dd9c913640292df27bff80a685bed3a3c990d59aa6ce24c352f8fc",
+                "sha256:8b8713b9e46a45b2af6b96f559bfb13b1e02006f4242c156cbadef27800a55a8",
+                "sha256:8dcb9673f108a93c1b52bfc51b0af422c2d08d4fc710ce9c839faad25020bb69",
+                "sha256:90a5551f6f5a5fa07010bf3d0b4ca2de21adafbbc0af6cb700b63cd767266cb9",
+                "sha256:910fdf2ac0637b9a77d1aad65f803bac414f0b06f720073438a7bd8906298192",
+                "sha256:91a5a0158648a67ff0004cb0df5df7dcc55bfc9ca154d9c01597a23ad54c8d0c",
+                "sha256:9a904f9572092bb6742ab7c16c623f0cdccbad9eeb2d14d4aa06284867bddd31",
+                "sha256:9c5fc1238ef197e7cad5c91415f524aaa51e004be5a9b35a1b8a84ade196f73f",
+                "sha256:a734c62efa42e7df94926d70fe7d37621c783dea9f707a98cdea796964d4cf74",
+                "sha256:a7974c490c014c48810d1dede6c754c3cc46598da758c25ca3b4001ac45b703f",
+                "sha256:a9e15c06491c69997dfa067369baab3bf094ecb74be9912bdc4339972323f252",
+                "sha256:ac8010afc2150d417ebda810e8df08dd3f544e0dd2acab5370cfa6bcc0662f8f",
+                "sha256:accfe93f42713c899fdac2747e8d0d5c659592df2792888c6c5f829472e4f85e",
+                "sha256:bb52c22bfffe2857e7aa13b4622afd0dd9d16ea7cc65fd2bf318d3223b1b6252",
+                "sha256:be604f60d45ace6b0b33dd990a66b4526f1a7a186ac411c942674625456ca548",
+                "sha256:c1f7a3ce79246aa0e92f5458d86c54f257fb5dfdc14a192651ba7ec2c00f8a05",
+                "sha256:c22c3ea6fba91d84fcb4cda30e64aff548fcf0c44c876e681f47d61d24b12e6b",
+                "sha256:c34ec9aebc04f11f4b978dd6caf697a2df2dd9b47d35aa4cc606cabcb9df69d7",
+                "sha256:c47ce6b8d90fe9646a25b6fb52284a14ff215c9595914af63a5933a49972ce36",
+                "sha256:de365a42acc65d74953f05e4772c974dad6c51cfc13c3240899f534d611be967",
+                "sha256:ece01a7ec71d9940cc654c482907a6b65df27251255097629d0dea781f255c6d",
+                "sha256:ed459b46012ae950dd2e17150e838ab08215421487371fa79d0eced8d1461d70",
+                "sha256:f17e6baf4cf01534c9de8a16c0c611f3d94925d1701bf5f4aff17003677d8ced",
+                "sha256:f29de3ef71a42a5822765def1febfb36e0859d33abf5c2ad240acad5c6a1b78d",
+                "sha256:f31422ff9486ae484f10ffc51b5ab2a60359e92d0716fcce1b3593d7bb8a9af6",
+                "sha256:f4244b7018b5753ecd10a6d324ec1f347da130c953a9c88432c7fbc8875d13be",
+                "sha256:f45653775f38f63dc0e6cd4f14323984c3149c05d6007b58cb154dd080ddc0dc",
+                "sha256:f72e27a62041cfb37a3de512247ece9f240a561e6c8662276beaf4d53d406db4",
+                "sha256:fc23f691fa0f5c140576b8c365bc942d577d861a9ee1142e4db468e4e17094fb",
+                "sha256:fd6ec8658da3480939c79b9e9e27e0db31dffcd4ba69c334e98c9976ac29140e",
+                "sha256:ff31d22ecc5fb85ef62c7d4afe8301d10c558d00dd24274d4bbe464380d3cd69",
+                "sha256:ff70ef093895fd53f4055ca75f93f047e088d1430888ca1229393a7c0521100f"
             ],
             "markers": "platform_python_implementation != 'PyPy'",
-            "version": "==3.10.11"
+            "version": "==3.10.12"
         },
         "packaging": {
             "hashes": [
@@ -887,6 +959,22 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==24.2"
+        },
+        "path": {
+            "hashes": [
+                "sha256:a6a6d916c910dc17e0ddc883358756c5a33d1b6dbdf5d6de86554f399053af58",
+                "sha256:d981989cf87598adc9f5b71ec5192d314a384836e81b4b1f34197138dc4ae659"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==16.16.0"
+        },
+        "pathvalidate": {
+            "hashes": [
+                "sha256:9a6255eb8f63c9e2135b9be97a5ce08f10230128c4ae7b3e935378b82b22c4c9",
+                "sha256:f5d07b1e2374187040612a1fcd2bcb2919f8db180df254c9581bb90bf903377d"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.2.1"
         },
         "pgvector": {
             "hashes": [
@@ -913,117 +1001,117 @@
         },
         "pydantic": {
             "hashes": [
-                "sha256:0aca0f045ff6e2f097f1fe89521115335f15049eeb8a7bef3dafe4b19a74e289",
-                "sha256:5e7807ba9201bdf61b1b58aa6eb690916c40a47acfb114b1b4fef3e7fd5b30fc"
+                "sha256:2bc2d7f17232e0841cbba4641e65ba1eb6fafb3a08de3a091ff3ce14a197c4fa",
+                "sha256:cfb96e45951117c3024e6b67b25cdc33a3cb7b2fa62e239f7af1378358a1d99e"
             ],
             "index": "pypi",
-            "version": "==2.10.0"
+            "version": "==2.10.2"
         },
         "pydantic-core": {
             "hashes": [
-                "sha256:0aa4d1b2eba9a325897308b3124014a142cdccb9f3e016f31d3ebee6b5ea5e75",
-                "sha256:0d06b667e53320332be2bf6f9461f4a9b78092a079b8ce8634c9afaa7e10cd9f",
-                "sha256:153017e3d6cd3ce979de06d84343ca424bb6092727375eba1968c8b4693c6ecb",
-                "sha256:15e350efb67b855cd014c218716feea4986a149ed1f42a539edd271ee074a196",
-                "sha256:185ef205256cd8b38431205698531026979db89a79587725c1e55c59101d64e9",
-                "sha256:1da0c98a85a6c6ed702d5556db3b09c91f9b0b78de37b7593e2de8d03238807a",
-                "sha256:225bfff5d425c34e1fd562cef52d673579d59b967d9de06178850c4802af9039",
-                "sha256:24f984fc7762ed5f806d9e8c4c77ea69fdb2afd987b4fd319ef06c87595a8c55",
-                "sha256:25a7fd4de38f7ff99a37e18fa0098c3140286451bc823d1746ba80cec5b433a1",
-                "sha256:2883b260f7a93235488699d39cbbd94fa7b175d3a8063fbfddd3e81ad9988cb2",
-                "sha256:2a51ce96224eadd1845150b204389623c8e129fde5a67a84b972bd83a85c6c40",
-                "sha256:2be0ad541bb9f059954ccf8877a49ed73877f862529575ff3d54bf4223e4dd61",
-                "sha256:31a2cae5f059329f9cfe3d8d266d3da1543b60b60130d186d9b6a3c20a346361",
-                "sha256:333c840a1303d1474f491e7be0b718226c730a39ead0f7dab2c7e6a2f3855555",
-                "sha256:33d14369739c5d07e2e7102cdb0081a1fa46ed03215e07f097b34e020b83b1ae",
-                "sha256:35380671c3c921fe8adf31ad349dc6f7588b7e928dbe44e1093789734f607399",
-                "sha256:359e7951f04ad35111b5ddce184db3391442345d0ab073aa63a95eb8af25a5ef",
-                "sha256:36aa167f69d8807ba7e341d67ea93e50fcaaf6bc433bb04939430fa3dab06f31",
-                "sha256:395e3e1148fa7809016231f8065f30bb0dc285a97b4dc4360cd86e17bab58af7",
-                "sha256:3e8d89c276234579cd3d095d5fa2a44eb10db9a218664a17b56363cddf226ff3",
-                "sha256:3eb8849445c26b41c5a474061032c53e14fe92a11a5db969f722a2716cd12206",
-                "sha256:3fd8bc2690e7c39eecdf9071b6a889ce7b22b72073863940edc2a0a23750ca90",
-                "sha256:400bf470e4327e920883b51e255617dfe4496d4e80c3fea0b5a5d0bf2c404dd4",
-                "sha256:4148dc9184ab79e356dc00a4199dc0ee8647973332cb385fc29a7cced49b9f9c",
-                "sha256:433689845288f9a1ee5714444e65957be26d30915f7745091ede4a83cfb2d7bb",
-                "sha256:43b61989068de9ce62296cde02beffabcadb65672207fc51e7af76dca75e6636",
-                "sha256:4523c4009c3f39d948e01962223c9f5538602e7087a628479b723c939fab262d",
-                "sha256:483c2213a609e7db2c592bbc015da58b6c75af7360ca3c981f178110d9787bcf",
-                "sha256:49633583eb7dc5cba61aaf7cdb2e9e662323ad394e543ee77af265736bcd3eaa",
-                "sha256:4b51f964fcbb02949fc546022e56cdb16cda457af485e9a3e8b78ac2ecf5d77e",
-                "sha256:4bf1340ae507f6da6360b24179c2083857c8ca7644aab65807023cf35404ea8d",
-                "sha256:4fb49cfdb53af5041aba909be00cccfb2c0d0a2e09281bf542371c5fd36ad04c",
-                "sha256:510b11e9c3b1a852876d1ccd8d5903684336d635214148637ceb27366c75a467",
-                "sha256:513cb14c0cc31a4dfd849a4674b20c46d87b364f997bbcb02282306f5e187abf",
-                "sha256:58560828ee0951bb125c6f2862fbc37f039996d19ceb6d8ff1905abf7da0bf3d",
-                "sha256:58ab0d979c969983cdb97374698d847a4acffb217d543e172838864636ef10d9",
-                "sha256:5982048129f40b082c2654de10c0f37c67a14f5ff9d37cf35be028ae982f26df",
-                "sha256:5ab325fc86fbc077284c8d7f996d904d30e97904a87d6fb303dce6b3de7ebba9",
-                "sha256:5cc822ab90a70ea3a91e6aed3afac570b276b1278c6909b1d384f745bd09c714",
-                "sha256:5f2b19b8d6fca432cb3acf48cf5243a7bf512988029b6e6fd27e9e8c0a204d85",
-                "sha256:5fc72fbfebbf42c0856a824b8b0dc2b5cd2e4a896050281a21cfa6fed8879cb1",
-                "sha256:6354e18a9be37bfa124d6b288a87fb30c673745806c92956f1a25e3ae6e76b96",
-                "sha256:678f66462058dd978702db17eb6a3633d634f7aa0deaea61e0a674152766d3fc",
-                "sha256:68950bc08f9735306322bfc16a18391fcaac99ded2509e1cc41d03ccb6013cfe",
-                "sha256:68ef5377eb582fa4343c9d0b57a5b094046d447b4c73dd9fbd9ffb216f829e7d",
-                "sha256:6b4c19525c3538fbc0bbda6229f9682fb8199ce9ac37395880e6952798e00373",
-                "sha256:6bb69bf3b6500f195c3deb69c1205ba8fc3cb21d1915f1f158a10d6b1ef29b6a",
-                "sha256:6e19401742ed7b69e51d8e4df3c03ad5ec65a83b36244479fd70edde2828a5d9",
-                "sha256:6f4a53af9e81d757756508b57cae1cf28293f0f31b9fa2bfcb416cc7fb230f9d",
-                "sha256:6fda87808429c520a002a85d6e7cdadbf58231d60e96260976c5b8f9a12a8e13",
-                "sha256:78f841523729e43e3928a364ec46e2e3f80e6625a4f62aca5c345f3f626c6e8a",
-                "sha256:7a6ebfac28fd51890a61df36ef202adbd77d00ee5aca4a3dadb3d9ed49cfb929",
-                "sha256:7b0202ebf2268954090209a84f9897345719e46a57c5f2c9b7b250ca0a9d3e63",
-                "sha256:8117839a9bdbba86e7f9df57018fe3b96cec934c3940b591b0fd3fbfb485864a",
-                "sha256:82e1ad4ca170e8af4c928b67cff731b6296e6a0a0981b97b2eb7c275cc4e15bd",
-                "sha256:836a4bfe0cc6d36dc9a9cc1a7b391265bf6ce9d1eb1eac62ac5139f5d8d9a6fa",
-                "sha256:84af1cf7bfdcbc6fcf5a5f70cc9896205e0350306e4dd73d54b6a18894f79386",
-                "sha256:84e35afd9e10b2698e6f2f32256678cb23ca6c1568d02628033a837638b3ed12",
-                "sha256:884f1806609c2c66564082540cffc96868c5571c7c3cf3a783f63f2fb49bd3cd",
-                "sha256:8a150392102c402c538190730fda06f3bce654fc498865579a9f2c1d2b425833",
-                "sha256:8e21d927469d04b39386255bf00d0feedead16f6253dcc85e9e10ddebc334084",
-                "sha256:8e96ca781e0c01e32115912ebdf7b3fb0780ce748b80d7d28a0802fa9fbaf44e",
-                "sha256:8ee4c2a75af9fe21269a4a0898c5425afb01af1f5d276063f57e2ae1bc64e191",
-                "sha256:91bc66f878557313c2a6bcf396e7befcffe5ab4354cfe4427318968af31143c3",
-                "sha256:951e71da6c89d354572098bada5ba5b5dc3a9390c933af8a614e37755d3d1840",
-                "sha256:99b2863c1365f43f74199c980a3d40f18a218fbe683dd64e470199db426c4d6a",
-                "sha256:9a8fbf506fde1529a1e3698198fe64bfbe2e0c09557bc6a7dcf872e7c01fec40",
-                "sha256:9ce048deb1e033e7a865ca384770bccc11d44179cf09e5193a535c4c2f497bdc",
-                "sha256:9fe94d9d2a2b4edd7a4b22adcd45814b1b59b03feb00e56deb2e89747aec7bfe",
-                "sha256:a291d0b4243a259c8ea7e2b84eb9ccb76370e569298875a7c5e3e71baf49057a",
-                "sha256:a5c022bb0d453192426221605efc865373dde43b17822a264671c53b068ac20c",
-                "sha256:abb4785894936d7682635726613c44578c420a096729f1978cd061a7e72d5275",
-                "sha256:b872c86d8d71827235c7077461c502feb2db3f87d9d6d5a9daa64287d75e4fa0",
-                "sha256:bf37b72834e7239cf84d4a0b2c050e7f9e48bced97bad9bdf98d26b8eb72e846",
-                "sha256:c0c431e4be5c1a0c6654e0c31c661cd89e0ca956ef65305c3c3fd96f4e72ca39",
-                "sha256:c5726eec789ee38f2c53b10b1821457b82274f81f4f746bb1e666d8741fcfadb",
-                "sha256:c6fcb3fa3855d583aa57b94cf146f7781d5d5bc06cb95cb3afece33d31aac39b",
-                "sha256:c86679f443e7085ea55a7376462553996c688395d18ef3f0d3dbad7838f857a2",
-                "sha256:c91e3c04f5191fd3fb68764bddeaf02025492d5d9f23343b283870f6ace69708",
-                "sha256:c921ad596ff1a82f9c692b0758c944355abc9f0de97a4c13ca60ffc6d8dc15d4",
-                "sha256:c9ed88b398ba7e3bad7bd64d66cc01dcde9cfcb7ec629a6fd78a82fa0b559d78",
-                "sha256:cd2ac6b919f7fed71b17fe0b4603c092a4c9b5bae414817c9c81d3c22d1e1bcc",
-                "sha256:d28ca7066d6cdd347a50d8b725dc10d9a1d6a1cce09836cf071ea6a2d4908be0",
-                "sha256:d29e235ce13c91902ef3efc3d883a677655b3908b1cbc73dee816e5e1f8f7739",
-                "sha256:d8b5ee4ae9170e2775d495b81f414cc20268041c42571530513496ba61e94ba3",
-                "sha256:db72e40628967f6dc572020d04b5f800d71264e0531c6da35097e73bdf38b003",
-                "sha256:df45c4073bed486ea2f18757057953afed8dd77add7276ff01bccb79982cf46c",
-                "sha256:dfa5f5c0a4c8fced1422dc2ca7eefd872d5d13eb33cf324361dbf1dbfba0a9fe",
-                "sha256:e015833384ca3e1a0565a79f5d953b0629d9138021c27ad37c92a9fa1af7623c",
-                "sha256:e15315691fe2253eb447503153acef4d7223dfe7e7702f9ed66539fcd0c43801",
-                "sha256:e65466b31be1070b4a5b7dbfbd14b247884cb8e8b79c64fb0f36b472912dbaea",
-                "sha256:e7820bb0d65e3ce1e3e70b6708c2f66143f55912fa02f4b618d0f08b61575f12",
-                "sha256:e851a051f7260e6d688267eb039c81f05f23a19431bd7dfa4bf5e3cb34c108cd",
-                "sha256:e9f9feee7f334b72ceae46313333d002b56f325b5f04271b4ae2aadd9e993ae4",
-                "sha256:eb40f828bc2f73f777d1eb8fee2e86cd9692a4518b63b6b5aa8af915dfd3207b",
-                "sha256:eb704155e73b833801c247f39d562229c0303f54770ca14fb1c053acb376cf10",
-                "sha256:edb1bfd45227dec8d50bc7c7d86463cd8728bcc574f9b07de7369880de4626a3",
-                "sha256:ee7d9d5537daf6d5c74a83b38a638cc001b648096c1cae8ef695b0c919d9d379",
-                "sha256:f57783fbaf648205ac50ae7d646f27582fc706be3977e87c3c124e7a92407b10",
-                "sha256:ff63a92f6e249514ef35bc795de10745be0226eaea06eb48b4bbeaa0c8850a4a"
+                "sha256:00e6424f4b26fe82d44577b4c842d7df97c20be6439e8e685d0d715feceb9fb9",
+                "sha256:029d9757eb621cc6e1848fa0b0310310de7301057f623985698ed7ebb014391b",
+                "sha256:02a3d637bd387c41d46b002f0e49c52642281edacd2740e5a42f7017feea3f2c",
+                "sha256:0325336f348dbee6550d129b1627cb8f5351a9dc91aad141ffb96d4937bd9529",
+                "sha256:062f60e512fc7fff8b8a9d680ff0ddaaef0193dba9fa83e679c0c5f5fbd018bc",
+                "sha256:0b3dfe500de26c52abe0477dde16192ac39c98f05bf2d80e76102d394bd13854",
+                "sha256:0e4216e64d203e39c62df627aa882f02a2438d18a5f21d7f721621f7a5d3611d",
+                "sha256:121ceb0e822f79163dd4699e4c54f5ad38b157084d97b34de8b232bcaad70278",
+                "sha256:159cac0a3d096f79ab6a44d77a961917219707e2a130739c64d4dd46281f5c2a",
+                "sha256:15aae984e46de8d376df515f00450d1522077254ef6b7ce189b38ecee7c9677c",
+                "sha256:15cc53a3179ba0fcefe1e3ae50beb2784dede4003ad2dfd24f81bba4b23a454f",
+                "sha256:161c27ccce13b6b0c8689418da3885d3220ed2eae2ea5e9b2f7f3d48f1d52c27",
+                "sha256:19910754e4cc9c63bc1c7f6d73aa1cfee82f42007e407c0f413695c2f7ed777f",
+                "sha256:1ba5e3963344ff25fc8c40da90f44b0afca8cfd89d12964feb79ac1411a260ac",
+                "sha256:1c00666a3bd2f84920a4e94434f5974d7bbc57e461318d6bb34ce9cdbbc1f6b2",
+                "sha256:1c39b07d90be6b48968ddc8c19e7585052088fd7ec8d568bb31ff64c70ae3c97",
+                "sha256:206b5cf6f0c513baffaeae7bd817717140770c74528f3e4c3e1cec7871ddd61a",
+                "sha256:258c57abf1188926c774a4c94dd29237e77eda19462e5bb901d88adcab6af919",
+                "sha256:2cdf7d86886bc6982354862204ae3b2f7f96f21a3eb0ba5ca0ac42c7b38598b9",
+                "sha256:2d4567c850905d5eaaed2f7a404e61012a51caf288292e016360aa2b96ff38d4",
+                "sha256:35c14ac45fcfdf7167ca76cc80b2001205a8d5d16d80524e13508371fb8cdd9c",
+                "sha256:38de0a70160dd97540335b7ad3a74571b24f1dc3ed33f815f0880682e6880131",
+                "sha256:3af385b0cee8df3746c3f406f38bcbfdc9041b5c2d5ce3e5fc6637256e60bbc5",
+                "sha256:3b748c44bb9f53031c8cbc99a8a061bc181c1000c60a30f55393b6e9c45cc5bd",
+                "sha256:3bbd5d8cc692616d5ef6fbbbd50dbec142c7e6ad9beb66b78a96e9c16729b089",
+                "sha256:3ccaa88b24eebc0f849ce0a4d09e8a408ec5a94afff395eb69baf868f5183107",
+                "sha256:3fa80ac2bd5856580e242dbc202db873c60a01b20309c8319b5c5986fbe53ce6",
+                "sha256:4228b5b646caa73f119b1ae756216b59cc6e2267201c27d3912b592c5e323b60",
+                "sha256:42b0e23f119b2b456d07ca91b307ae167cc3f6c846a7b169fca5326e32fdc6cf",
+                "sha256:45cf8588c066860b623cd11c4ba687f8d7175d5f7ef65f7129df8a394c502de5",
+                "sha256:45d9c5eb9273aa50999ad6adc6be5e0ecea7e09dbd0d31bd0c65a55a2592ca08",
+                "sha256:4603137322c18eaf2e06a4495f426aa8d8388940f3c457e7548145011bb68e05",
+                "sha256:46ccfe3032b3915586e469d4972973f893c0a2bb65669194a5bdea9bacc088c2",
+                "sha256:4fefee876e07a6e9aad7a8c8c9f85b0cdbe7df52b8a9552307b09050f7512c7e",
+                "sha256:5556470f1a2157031e676f776c2bc20acd34c1990ca5f7e56f1ebf938b9ab57c",
+                "sha256:57866a76e0b3823e0b56692d1a0bf722bffb324839bb5b7226a7dbd6c9a40b17",
+                "sha256:5897bec80a09b4084aee23f9b73a9477a46c3304ad1d2d07acca19723fb1de62",
+                "sha256:58ca98a950171f3151c603aeea9303ef6c235f692fe555e883591103da709b23",
+                "sha256:5ca038c7f6a0afd0b2448941b6ef9d5e1949e999f9e5517692eb6da58e9d44be",
+                "sha256:5f6c8a66741c5f5447e047ab0ba7a1c61d1e95580d64bce852e3df1f895c4067",
+                "sha256:5f8c4718cd44ec1580e180cb739713ecda2bdee1341084c1467802a417fe0f02",
+                "sha256:5fde892e6c697ce3e30c61b239330fc5d569a71fefd4eb6512fc6caec9dd9e2f",
+                "sha256:62a763352879b84aa31058fc931884055fd75089cccbd9d58bb6afd01141b235",
+                "sha256:62ba45e21cf6571d7f716d903b5b7b6d2617e2d5d67c0923dc47b9d41369f840",
+                "sha256:64c65f40b4cd8b0e049a8edde07e38b476da7e3aaebe63287c899d2cff253fa5",
+                "sha256:655d7dd86f26cb15ce8a431036f66ce0318648f8853d709b4167786ec2fa4807",
+                "sha256:66ff044fd0bb1768688aecbe28b6190f6e799349221fb0de0e6f4048eca14c16",
+                "sha256:672ebbe820bb37988c4d136eca2652ee114992d5d41c7e4858cdd90ea94ffe5c",
+                "sha256:6b9af86e1d8e4cfc82c2022bfaa6f459381a50b94a29e95dcdda8442d6d83864",
+                "sha256:6e0bd57539da59a3e4671b90a502da9a28c72322a4f17866ba3ac63a82c4498e",
+                "sha256:71a5e35c75c021aaf400ac048dacc855f000bdfed91614b4a726f7432f1f3d6a",
+                "sha256:7597c07fbd11515f654d6ece3d0e4e5093edc30a436c63142d9a4b8e22f19c35",
+                "sha256:764be71193f87d460a03f1f7385a82e226639732214b402f9aa61f0d025f0737",
+                "sha256:7699b1df36a48169cdebda7ab5a2bac265204003f153b4bd17276153d997670a",
+                "sha256:7ccebf51efc61634f6c2344da73e366c75e735960b5654b63d7e6f69a5885fa3",
+                "sha256:7f7059ca8d64fea7f238994c97d91f75965216bcbe5f695bb44f354893f11d52",
+                "sha256:8065914ff79f7eab1599bd80406681f0ad08f8e47c880f17b416c9f8f7a26d05",
+                "sha256:816f5aa087094099fff7edabb5e01cc370eb21aa1a1d44fe2d2aefdfb5599b31",
+                "sha256:81f2ec23ddc1b476ff96563f2e8d723830b06dceae348ce02914a37cb4e74b89",
+                "sha256:84286494f6c5d05243456e04223d5a9417d7f443c3b76065e75001beb26f88de",
+                "sha256:8bf7b66ce12a2ac52d16f776b31d16d91033150266eb796967a7e4621707e4f6",
+                "sha256:8f1edcea27918d748c7e5e4d917297b2a0ab80cad10f86631e488b7cddf76a36",
+                "sha256:981fb88516bd1ae8b0cbbd2034678a39dedc98752f264ac9bc5839d3923fa04c",
+                "sha256:98476c98b02c8e9b2eec76ac4156fd006628b1b2d0ef27e548ffa978393fd154",
+                "sha256:992cea5f4f3b29d6b4f7f1726ed8ee46c8331c6b4eed6db5b40134c6fe1768bb",
+                "sha256:9a3b0793b1bbfd4146304e23d90045f2a9b5fd5823aa682665fbdaf2a6c28f3e",
+                "sha256:9a42d6a8156ff78981f8aa56eb6394114e0dedb217cf8b729f438f643608cbcd",
+                "sha256:9c10c309e18e443ddb108f0ef64e8729363adbfd92d6d57beec680f6261556f3",
+                "sha256:9cbd94fc661d2bab2bc702cddd2d3370bbdcc4cd0f8f57488a81bcce90c7a54f",
+                "sha256:9fdcf339322a3fae5cbd504edcefddd5a50d9ee00d968696846f089b4432cf78",
+                "sha256:a0697803ed7d4af5e4c1adf1670af078f8fcab7a86350e969f454daf598c4960",
+                "sha256:a28af0695a45f7060e6f9b7092558a928a28553366519f64083c63a44f70e618",
+                "sha256:a2e02889071850bbfd36b56fd6bc98945e23670773bc7a76657e90e6b6603c08",
+                "sha256:a33cd6ad9017bbeaa9ed78a2e0752c5e250eafb9534f308e7a5f7849b0b1bfb4",
+                "sha256:a3cb37038123447cf0f3ea4c74751f6a9d7afef0eb71aa07bf5f652b5e6a132c",
+                "sha256:a57847b090d7892f123726202b7daa20df6694cbd583b67a592e856bff603d6c",
+                "sha256:a5a8e19d7c707c4cadb8c18f5f60c843052ae83c20fa7d44f41594c644a1d330",
+                "sha256:ac3b20653bdbe160febbea8aa6c079d3df19310d50ac314911ed8cc4eb7f8cb8",
+                "sha256:ac6c2c45c847bbf8f91930d88716a0fb924b51e0c6dad329b793d670ec5db792",
+                "sha256:acc07b2cfc5b835444b44a9956846b578d27beeacd4b52e45489e93276241025",
+                "sha256:aee66be87825cdf72ac64cb03ad4c15ffef4143dbf5c113f64a5ff4f81477bf9",
+                "sha256:af52d26579b308921b73b956153066481f064875140ccd1dfd4e77db89dbb12f",
+                "sha256:b94d4ba43739bbe8b0ce4262bcc3b7b9f31459ad120fb595627eaeb7f9b9ca01",
+                "sha256:ba630d5e3db74c79300d9a5bdaaf6200172b107f263c98a0539eeecb857b2337",
+                "sha256:bed0f8a0eeea9fb72937ba118f9db0cb7e90773462af7962d382445f3005e5a4",
+                "sha256:bf99c8404f008750c846cb4ac4667b798a9f7de673ff719d705d9b2d6de49c5f",
+                "sha256:c3027001c28434e7ca5a6e1e527487051136aa81803ac812be51802150d880dd",
+                "sha256:c65af9088ac534313e1963443d0ec360bb2b9cba6c2909478d22c2e363d98a51",
+                "sha256:d0165ab2914379bd56908c02294ed8405c252250668ebcb438a55494c69f44ab",
+                "sha256:d1b26e1dff225c31897696cab7d4f0a315d4c0d9e8666dbffdb28216f3b17fdc",
+                "sha256:d950caa237bb1954f1b8c9227b5065ba6875ac9771bb8ec790d956a699b78676",
+                "sha256:dc61505e73298a84a2f317255fcc72b710b72980f3a1f670447a21efc88f8381",
+                "sha256:e173486019cc283dc9778315fa29a363579372fe67045e971e89b6365cc035ed",
+                "sha256:e1f735dc43da318cad19b4173dd1ffce1d84aafd6c9b782b3abc04a0d5a6f5bb",
+                "sha256:e9386266798d64eeb19dd3677051f5705bf873e98e15897ddb7d76f477131967",
+                "sha256:f216dbce0e60e4d03e0c4353c7023b202d95cbaeff12e5fd2e82ea0a66905073",
+                "sha256:f4e5658dbffe8843a0f12366a4c2d1c316dbe09bb4dfbdc9d2d9cd6031de8aae",
+                "sha256:f5a823165e6d04ccea61a9f0576f345f8ce40ed533013580e087bd4d7442b52c",
+                "sha256:f69ed81ab24d5a3bd93861c8c4436f54afdf8e8cc421562b0c7504cf3be58206",
+                "sha256:f82d068a2d6ecfc6e054726080af69a6764a10015467d7d7b9f66d6ed5afa23b"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.27.0"
+            "version": "==2.27.1"
         },
         "pypdf2": {
             "hashes": [
@@ -1032,6 +1120,17 @@
             ],
             "index": "pypi",
             "version": "==3.0.1"
+        },
+        "pytablereader": {
+            "extras": [
+                "md"
+            ],
+            "hashes": [
+                "sha256:2ce0e81b1035ba6b345cc1edbf5734780ed089fdead05c1fd12869a09cc0c3ce",
+                "sha256:ad97308308525cafe0eaa4b6a80a02499e0b4c6c979efb17452d302ad78bd5b1"
+            ],
+            "index": "pypi",
+            "version": "==0.31.4"
         },
         "python-dateutil": {
             "hashes": [
@@ -1106,6 +1205,14 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==6.0.2"
+        },
+        "referencing": {
+            "hashes": [
+                "sha256:25b42124a6c8b632a425174f24087783efb348a6f1e0008e63cd4466fedf703c",
+                "sha256:eda6d3234d62814d1c64e305c1331c9a3a6132da475ab6382eaa997b21ee75de"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==0.35.1"
         },
         "regex": {
             "hashes": [
@@ -1223,6 +1330,102 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.0.0"
         },
+        "rpds-py": {
+            "hashes": [
+                "sha256:031819f906bb146561af051c7cef4ba2003d28cff07efacef59da973ff7969ba",
+                "sha256:0626238a43152918f9e72ede9a3b6ccc9e299adc8ade0d67c5e142d564c9a83d",
+                "sha256:085ed25baac88953d4283e5b5bd094b155075bb40d07c29c4f073e10623f9f2e",
+                "sha256:0a9e0759e7be10109645a9fddaaad0619d58c9bf30a3f248a2ea57a7c417173a",
+                "sha256:0c025820b78817db6a76413fff6866790786c38f95ea3f3d3c93dbb73b632202",
+                "sha256:1ff2eba7f6c0cb523d7e9cff0903f2fe1feff8f0b2ceb6bd71c0e20a4dcee271",
+                "sha256:20cc1ed0bcc86d8e1a7e968cce15be45178fd16e2ff656a243145e0b439bd250",
+                "sha256:241e6c125568493f553c3d0fdbb38c74babf54b45cef86439d4cd97ff8feb34d",
+                "sha256:2c51d99c30091f72a3c5d126fad26236c3f75716b8b5e5cf8effb18889ced928",
+                "sha256:2d6129137f43f7fa02d41542ffff4871d4aefa724a5fe38e2c31a4e0fd343fb0",
+                "sha256:30b912c965b2aa76ba5168fd610087bad7fcde47f0a8367ee8f1876086ee6d1d",
+                "sha256:30bdc973f10d28e0337f71d202ff29345320f8bc49a31c90e6c257e1ccef4333",
+                "sha256:320c808df533695326610a1b6a0a6e98f033e49de55d7dc36a13c8a30cfa756e",
+                "sha256:32eb88c30b6a4f0605508023b7141d043a79b14acb3b969aa0b4f99b25bc7d4a",
+                "sha256:3b766a9f57663396e4f34f5140b3595b233a7b146e94777b97a8413a1da1be18",
+                "sha256:3b929c2bb6e29ab31f12a1117c39f7e6d6450419ab7464a4ea9b0b417174f044",
+                "sha256:3e30a69a706e8ea20444b98a49f386c17b26f860aa9245329bab0851ed100677",
+                "sha256:3e53861b29a13d5b70116ea4230b5f0f3547b2c222c5daa090eb7c9c82d7f664",
+                "sha256:40c91c6e34cf016fa8e6b59d75e3dbe354830777fcfd74c58b279dceb7975b75",
+                "sha256:4991ca61656e3160cdaca4851151fd3f4a92e9eba5c7a530ab030d6aee96ec89",
+                "sha256:4ab2c2a26d2f69cdf833174f4d9d86118edc781ad9a8fa13970b527bf8236027",
+                "sha256:4e8921a259f54bfbc755c5bbd60c82bb2339ae0324163f32868f63f0ebb873d9",
+                "sha256:4eb2de8a147ffe0626bfdc275fc6563aa7bf4b6db59cf0d44f0ccd6ca625a24e",
+                "sha256:5145282a7cd2ac16ea0dc46b82167754d5e103a05614b724457cffe614f25bd8",
+                "sha256:520ed8b99b0bf86a176271f6fe23024323862ac674b1ce5b02a72bfeff3fff44",
+                "sha256:52c041802a6efa625ea18027a0723676a778869481d16803481ef6cc02ea8cb3",
+                "sha256:5555db3e618a77034954b9dc547eae94166391a98eb867905ec8fcbce1308d95",
+                "sha256:58a0e345be4b18e6b8501d3b0aa540dad90caeed814c515e5206bb2ec26736fd",
+                "sha256:590ef88db231c9c1eece44dcfefd7515d8bf0d986d64d0caf06a81998a9e8cab",
+                "sha256:5afb5efde74c54724e1a01118c6e5c15e54e642c42a1ba588ab1f03544ac8c7a",
+                "sha256:688c93b77e468d72579351a84b95f976bd7b3e84aa6686be6497045ba84be560",
+                "sha256:6b4ef7725386dc0762857097f6b7266a6cdd62bfd209664da6712cb26acef035",
+                "sha256:6bc0e697d4d79ab1aacbf20ee5f0df80359ecf55db33ff41481cf3e24f206919",
+                "sha256:6dcc4949be728ede49e6244eabd04064336012b37f5c2200e8ec8eb2988b209c",
+                "sha256:6f54e7106f0001244a5f4cf810ba8d3f9c542e2730821b16e969d6887b664266",
+                "sha256:808f1ac7cf3b44f81c9475475ceb221f982ef548e44e024ad5f9e7060649540e",
+                "sha256:8404b3717da03cbf773a1d275d01fec84ea007754ed380f63dfc24fb76ce4592",
+                "sha256:878f6fea96621fda5303a2867887686d7a198d9e0f8a40be100a63f5d60c88c9",
+                "sha256:8a7ff941004d74d55a47f916afc38494bd1cfd4b53c482b77c03147c91ac0ac3",
+                "sha256:95a5bad1ac8a5c77b4e658671642e4af3707f095d2b78a1fdd08af0dfb647624",
+                "sha256:97ef67d9bbc3e15584c2f3c74bcf064af36336c10d2e21a2131e123ce0f924c9",
+                "sha256:98486337f7b4f3c324ab402e83453e25bb844f44418c066623db88e4c56b7c7b",
+                "sha256:98e4fe5db40db87ce1c65031463a760ec7906ab230ad2249b4572c2fc3ef1f9f",
+                "sha256:998a8080c4495e4f72132f3d66ff91f5997d799e86cec6ee05342f8f3cda7dca",
+                "sha256:9afe42102b40007f588666bc7de82451e10c6788f6f70984629db193849dced1",
+                "sha256:9e20da3957bdf7824afdd4b6eeb29510e83e026473e04952dca565170cd1ecc8",
+                "sha256:a017f813f24b9df929674d0332a374d40d7f0162b326562daae8066b502d0590",
+                "sha256:a429b99337062877d7875e4ff1a51fe788424d522bd64a8c0a20ef3021fdb6ed",
+                "sha256:a58ce66847711c4aa2ecfcfaff04cb0327f907fead8945ffc47d9407f41ff952",
+                "sha256:a78d8b634c9df7f8d175451cfeac3810a702ccb85f98ec95797fa98b942cea11",
+                "sha256:a89a8ce9e4e75aeb7fa5d8ad0f3fecdee813802592f4f46a15754dcb2fd6b061",
+                "sha256:a8eeec67590e94189f434c6d11c426892e396ae59e4801d17a93ac96b8c02a6c",
+                "sha256:aaeb25ccfb9b9014a10eaf70904ebf3f79faaa8e60e99e19eef9f478651b9b74",
+                "sha256:ad116dda078d0bc4886cb7840e19811562acdc7a8e296ea6ec37e70326c1b41c",
+                "sha256:af04ac89c738e0f0f1b913918024c3eab6e3ace989518ea838807177d38a2e94",
+                "sha256:af4a644bf890f56e41e74be7d34e9511e4954894d544ec6b8efe1e21a1a8da6c",
+                "sha256:b21747f79f360e790525e6f6438c7569ddbfb1b3197b9e65043f25c3c9b489d8",
+                "sha256:b229ce052ddf1a01c67d68166c19cb004fb3612424921b81c46e7ea7ccf7c3bf",
+                "sha256:b4de1da871b5c0fd5537b26a6fc6814c3cc05cabe0c941db6e9044ffbb12f04a",
+                "sha256:b80b4690bbff51a034bfde9c9f6bf9357f0a8c61f548942b80f7b66356508bf5",
+                "sha256:b876f2bc27ab5954e2fd88890c071bd0ed18b9c50f6ec3de3c50a5ece612f7a6",
+                "sha256:b8f107395f2f1d151181880b69a2869c69e87ec079c49c0016ab96860b6acbe5",
+                "sha256:b9b76e2afd585803c53c5b29e992ecd183f68285b62fe2668383a18e74abe7a3",
+                "sha256:c2b2f71c6ad6c2e4fc9ed9401080badd1469fa9889657ec3abea42a3d6b2e1ed",
+                "sha256:c3761f62fcfccf0864cc4665b6e7c3f0c626f0380b41b8bd1ce322103fa3ef87",
+                "sha256:c38dbf31c57032667dd5a2f0568ccde66e868e8f78d5a0d27dcc56d70f3fcd3b",
+                "sha256:ca9989d5d9b1b300bc18e1801c67b9f6d2c66b8fd9621b36072ed1df2c977f72",
+                "sha256:cbd7504a10b0955ea287114f003b7ad62330c9e65ba012c6223dba646f6ffd05",
+                "sha256:d167e4dbbdac48bd58893c7e446684ad5d425b407f9336e04ab52e8b9194e2ed",
+                "sha256:d2132377f9deef0c4db89e65e8bb28644ff75a18df5293e132a8d67748397b9f",
+                "sha256:da52d62a96e61c1c444f3998c434e8b263c384f6d68aca8274d2e08d1906325c",
+                "sha256:daa8efac2a1273eed2354397a51216ae1e198ecbce9036fba4e7610b308b6153",
+                "sha256:dc5695c321e518d9f03b7ea6abb5ea3af4567766f9852ad1560f501b17588c7b",
+                "sha256:de552f4a1916e520f2703ec474d2b4d3f86d41f353e7680b597512ffe7eac5d0",
+                "sha256:de609a6f1b682f70bb7163da745ee815d8f230d97276db049ab447767466a09d",
+                "sha256:e12bb09678f38b7597b8346983d2323a6482dcd59e423d9448108c1be37cac9d",
+                "sha256:e168afe6bf6ab7ab46c8c375606298784ecbe3ba31c0980b7dcbb9631dcba97e",
+                "sha256:e78868e98f34f34a88e23ee9ccaeeec460e4eaf6db16d51d7a9b883e5e785a5e",
+                "sha256:e860f065cc4ea6f256d6f411aba4b1251255366e48e972f8a347cf88077b24fd",
+                "sha256:ea3a6ac4d74820c98fcc9da4a57847ad2cc36475a8bd9683f32ab6d47a2bd682",
+                "sha256:ebf64e281a06c904a7636781d2e973d1f0926a5b8b480ac658dc0f556e7779f4",
+                "sha256:ed6378c9d66d0de903763e7706383d60c33829581f0adff47b6535f1802fa6db",
+                "sha256:ee1e4fc267b437bb89990b2f2abf6c25765b89b72dd4a11e21934df449e0c976",
+                "sha256:ee4eafd77cc98d355a0d02f263efc0d3ae3ce4a7c24740010a8b4012bbb24937",
+                "sha256:efec946f331349dfc4ae9d0e034c263ddde19414fe5128580f512619abed05f1",
+                "sha256:f414da5c51bf350e4b7960644617c130140423882305f7574b6cf65a3081cecb",
+                "sha256:f71009b0d5e94c0e86533c0b27ed7cacc1239cb51c178fd239c3cfefefb0400a",
+                "sha256:f983e4c2f603c95dde63df633eec42955508eefd8d0f0e6d236d31a044c882d7",
+                "sha256:faa5e8496c530f9c71f2b4e1c49758b06e5f4055e17144906245c99fa6d45356",
+                "sha256:fed5dfefdf384d6fe975cc026886aece4f292feaf69d0eeb716cfd3c5a4dd8be"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==0.21.0"
+        },
         "s3transfer": {
             "hashes": [
                 "sha256:244a76a24355363a68164241438de1b72f8781664920260c48465896b712a41e",
@@ -1230,6 +1433,14 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==0.10.4"
+        },
+        "setuptools": {
+            "hashes": [
+                "sha256:8199222558df7c86216af4f84c30e9b34a61d8ba19366cc914424cdbd28252f6",
+                "sha256:ce74b49e8f7110f9bf04883b730f4765b774ef3ef28f722cce7c273d253aaf7d"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==75.6.0"
         },
         "six": {
             "hashes": [
@@ -1318,6 +1529,14 @@
             "index": "pypi",
             "version": "==2.0.36"
         },
+        "tabledata": {
+            "hashes": [
+                "sha256:4abad1c996d8607e23b045b44dc0c5f061668f3c37585302c5f6c84c93a89962",
+                "sha256:c90daaba9a408e4397934b3ff2f6c06797d5289676420bf520c741ad43e6ff91"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.3.3"
+        },
         "tenacity": {
             "hashes": [
                 "sha256:807f37ca97d62aa361264d497b0e31e92b8027044942bfa756160d908320d73b",
@@ -1365,11 +1584,19 @@
         },
         "tqdm": {
             "hashes": [
-                "sha256:0cd8af9d56911acab92182e88d763100d4788bdf421d251616040cc4d44863be",
-                "sha256:fe5a6f95e6fe0b9755e9469b77b9c3cf850048224ecaa8293d7d2d31f97d869a"
+                "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2",
+                "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==4.67.0"
+            "version": "==4.67.1"
+        },
+        "typepy": {
+            "hashes": [
+                "sha256:b69fd48b9f50cdb3809906eef36b855b3134ff66c8893a4f8580abddb0b39517",
+                "sha256:d5d1022a424132622993800f1d2cd16cfdb691ac4e3b9c325f0fcb37799db1ae"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.3.2"
         },
         "typing-extensions": {
             "hashes": [

--- a/connectors/db/file.py
+++ b/connectors/db/file.py
@@ -73,7 +73,7 @@ def _get_table_row_lines(table: TableData) -> list[str]:
     table_lines = []
     for _, rows in table.as_dict().items():
         for row in rows:
-            line = " \t| ".join(
+            line = "* " + " \t| ".join(
                 [f"{header}: {row_content or 'null'}" for header, row_content in row.items()]
             )
             table_lines.append(line)

--- a/connectors/db/file.py
+++ b/connectors/db/file.py
@@ -7,7 +7,9 @@ from typing import Optional
 import html2text
 import mdformat
 import PyPDF2
+import pytablereader as ptr
 from bs4 import BeautifulSoup
+from tabledata import TableData
 
 log = logging.getLogger("tangerine.file")
 
@@ -40,6 +42,11 @@ def validate_file_type(full_path: str) -> None:
 
 
 def _remove_large_md_code_blocks(text):
+    """
+    Replaces markdown code blocks longer than 9 lines with redirection text
+
+    This is to avoid large code blocks getting broken up across text chunks
+    """
     lines = []
     code_lines = []
     in_code_block = False
@@ -62,80 +69,138 @@ def _remove_large_md_code_blocks(text):
     return "\n".join(lines)
 
 
-def _html_to_md(text):
+def _get_table_row_lines(table: TableData) -> list[str]:
+    table_lines = []
+    for _, rows in table.as_dict().items():
+        for row in rows:
+            line = " \t| ".join(
+                [f"{header}: {row_content or 'null'}" for header, row_content in row.items()]
+            )
+            table_lines.append(line)
+
+    return table_lines
+
+
+def _convert_md_tables(text: str) -> str:
+    """
+    Converts tables into plain with with each row having "header: value" statements
+
+    Intended to preserve the context of the table headers across text chunks
+    """
+    # parse tables found in this text using pytablereader
+    table_loader = ptr.MarkdownTableTextLoader(text)
+    tables = table_loader.load()
+    table_for_regex = dict()
+    for table in tables:
+        # create a regex pattern to match: '| header1   | header2   | (and so on)... |'
+        headers = [re.escape(header) for header in table.headers]
+        re_str = r"\| " + r"[\t ]+\| ".join(headers) + r"[\t ]+\|"
+        table_for_regex[re_str] = table
+
+    line_num = 0
+    lines = text.split("\n")
+    new_lines = []
+
+    while line_num < len(lines):
+        line = lines[line_num]
+        for re_str in table_for_regex:
+            line_without_styling = re.sub(r"[*_~]", "", line)
+            if re.findall(re_str, line_without_styling):
+                # we found the start of a table
+                table = table_for_regex[re_str]
+                row_lines = _get_table_row_lines(table)
+                new_lines.append(
+                    "<the table below was condensed using 'header: value' format for rows>"
+                )
+                new_lines.extend(row_lines)
+                # skip over table rows and 2 header lines when continuing to process the text
+                line_num += len(row_lines) + 2
+                break
+        else:
+            new_lines.append(line)
+            line_num += 1
+
+    return "\n".join(new_lines)
+
+
+def _process_md(text: str) -> str:
+    """
+    Process markdown text to yield better text chunks when text is split
+
+    1. Remove excessive newlines before/after code blocks
+    2. Use mdformat for general cleanup
+    3. Remove large code blocks
+    4. Convert tables into condensed format
+    """
+    # strip empty newlines before end of code blocks
+    md = re.sub(r"\n\n+```", "\n```", text)
+    # strip empty newlines after the start of a code block
+    md = re.sub(r"```\n\n+", "```\n", md)
+    # use opinionated formatter
+    md = mdformat.text(md)
+
+    md = _remove_large_md_code_blocks(md)
+    md = _convert_md_tables(md)
+
+    return md
+
+
+def _mkdocs_to_md(md_content: str) -> str:
     """
     Parse a .html page that has been composed with mkdocs
 
-    It is assumed that the page contains 'md-content' which was compiled based on .md
-
-    TODO: possibly handle html pages not built with mkdocs
+    Converts the page back into md using html2text and addresses formatting issues that
+    are commonly found after the conversion.
     """
-    md = ""
-    soup = BeautifulSoup(text, "lxml")
-    # extract 'md-content', this ignores nav/header/footer/etc.
-    md_content = soup.find("div", class_="md-content")
-    if md_content:
-        # remove "Edit this page" button
-        edit_button = md_content.find("a", title="Edit this page")
-        if edit_button:
-            edit_button.decompose()
+    # remove "Edit this page" button
+    edit_button = md_content.find("a", title="Edit this page")
+    if edit_button:
+        edit_button.decompose()
 
-        # remove line numbers from code blocks
-        linenos_columns = md_content.find_all("td", class_="linenos")
-        for linenos_column in linenos_columns:
-            linenos_column.decompose()
+    # remove line numbers from code blocks
+    linenos_columns = md_content.find_all("td", class_="linenos")
+    for linenos_column in linenos_columns:
+        linenos_column.decompose()
 
-        h = html2text.HTML2Text()
-        h.ignore_images = True
-        h.mark_code = True
-        h.body_width = 0
-        h.ignore_emphasis = True
-        h.wrap_links = False
-        h.ignore_tables = True
+    h = html2text.HTML2Text()
+    h.ignore_images = True
+    h.mark_code = True
+    h.body_width = 0
+    h.ignore_emphasis = True
+    h.wrap_links = False
+    h.ignore_tables = True
 
-        html2text_output = h.handle(str(md_content))
+    html2text_output = h.handle(str(md_content))
 
-        md_lines = []
-        in_code_block = False
+    md_lines = []
+    in_code_block = False
 
-        for line in html2text_output.split("\n"):
-            # remove non printable chars (like paragraph markers)
-            line = "".join(filter(lambda char: char in string.printable, line))
+    for line in html2text_output.split("\n"):
+        # remove non printable chars (like paragraph markers)
+        line = "".join(filter(lambda char: char in string.printable, line))
 
-            # remove trailing "#" from header lines
-            if re.match(r"#+ \S+", line):
-                line = line.rstrip("\\\\#")
+        # remove trailing "#" from header lines
+        if re.match(r"#+ \S+", line):
+            line = line.rstrip("\\\\#")
 
-            # replace html2text code block start/end with standard md
-            if "[code]" in line:
-                in_code_block = True
-                line = line.replace("[code]", "```")
-            elif "[/code]" in line:
-                in_code_block = False
-                line = line.replace("[/code]", "```")
-            if in_code_block:
-                # also fix indent, html2text indents all code content by 4 spaces
-                if line.startswith("```"):
-                    # start of code block and the txt may be on the same line...
-                    #   eg: ```    <text>
-                    line = f"```\n{line[8:]}"
-                else:
-                    line = line[4:]
-            md_lines.append(line)
+        # replace html2text code block start/end with standard md
+        if "[code]" in line:
+            in_code_block = True
+            line = line.replace("[code]", "```")
+        elif "[/code]" in line:
+            in_code_block = False
+            line = line.replace("[/code]", "```")
+        if in_code_block:
+            # also fix indent, html2text indents all code content by 4 spaces
+            if line.startswith("```"):
+                # start of code block and the txt may be on the same line...
+                #   eg: ```    <text>
+                line = f"```\n{line[8:]}"
+            else:
+                line = line[4:]
+        md_lines.append(line)
 
-        md = "\n".join(md_lines)
-
-        # strip empty newlines before end of code blocks
-        md = re.sub(r"\n\n+```", "\n```", md)
-        # strip empty newlines after the start of a code block
-        md = re.sub(r"```\n\n+", "```\n", md)
-        # finally, use opinionated formatter
-        md = mdformat.text(md)
-    else:
-        log.error("no 'md-content' div found")
-
-    md = _remove_large_md_code_blocks(md)
-
+    md = "\n".join(md_lines)
     return md
 
 
@@ -195,10 +260,21 @@ class File:
 
             return text_content
 
-        elif self.full_path.endswith(".html"):
-            return _html_to_md(self.content)
+        if self.full_path.endswith(".html"):
+            soup = BeautifulSoup(self.content, "lxml")
+            # look for 'md-content' in the page, this ignores nav/header/footer/etc.
+            md_content = soup.find("div", class_="md-content")
+            if md_content:
+                # assume this is an mkdocs html page
+                md = _mkdocs_to_md(md_content)
+                return _process_md(md)
+            else:
+                return self.content
 
-        if self.full_path.endswith((".md", ".txt", ".rst", ".html")):
+        if self.full_path.endswith(".md"):
+            return _process_md(self.content)
+
+        if self.full_path.endswith(".txt", ".rst"):
             return self.content
 
         return ""

--- a/connectors/db/vector.py
+++ b/connectors/db/vector.py
@@ -1,8 +1,8 @@
+import itertools
 import json
 import logging
 import math
 from operator import itemgetter
-import itertools
 
 from langchain_core.documents import Document
 from langchain_openai import OpenAIEmbeddings
@@ -92,7 +92,7 @@ class VectorStoreInterface:
         text_splitter = RecursiveCharacterTextSplitter(
             chunk_size=self.vector_chunk_size,
             chunk_overlap=self.vector_chunk_overlap,
-            separators=TXT_SEPARATORS,
+            separators=TXT_SEPARATORS,  # todo: split on more doc types
         )
 
         chunks = text_splitter.split_text(text)


### PR DESCRIPTION
Currently when we split markdown text, we sometimes see single rows in a text chunk. It is probably a combination of a large amount of white space being used in the tables, combined with the fact we split along `\n` as a separator. A row stored by itself in a chunk without the table headers is lacking context about the content.

1. Run the same markdown processing logic on mkdocs .html files and plain .md files
2. Add code to condense large tables so that the header context is preserved within each text chunk when the text is split for embedding. Also, since we are removing a lot of whitespace, we should hopefully be able to capture more rows in a chunk before splitting again.

For example, a table like this:
```
| header1      | header2      | header3      |
| ------------ | ------------ | ------------ |
| A            | B            | C            |
| D            | E            | F            |
```

Will be condensed into this:
```
<the table below was condensed using 'header: value' format for rows>
* header1: A     | header2: B     | header3: C
* header1: D     | header2: E     | header3: F
```

The `\t` + `|` is just for slightly easier readability when an end user views the citations, and `|` should be a good separator since it is unlikely for a table cell's text to contain that character.