### PR TITLE
Add FORCE_RESYNC_UNTIL option

### DIFF
--- a/openshift/s3sync-cronjob.template.yaml
+++ b/openshift/s3sync-cronjob.template.yaml
@@ -27,6 +27,8 @@ parameters:
     value: quay.io/tangerine/tangerine-backend
   - name: IMAGE_TAG
     value: latest
+  - name: FORCE_RESYNC_UNTIL
+    value: '0001-01-01T00:00:00Z'  # default is "the start of time", it will never run
 
 objects:
 - kind: Secret
@@ -150,6 +152,8 @@ objects:
                       secretKeyRef:
                         name: embed-api-key
                         key: api_key
+                  - name: FORCE_RESYNC_UNTIL
+                    value: ${FORCE_RESYNC_UNTIL}
                 imagePullPolicy: IfNotPresent
                 image: ${IMAGE}:${IMAGE_TAG}
             restartPolicy: Never


### PR DESCRIPTION
This allows an env var to be set on the cronjob (an isoformat timestamp) that will cause the job to run with force_resync=True as long as `current_time < until_time`