### PR TITLE
Export metrics endpoint for s3sync cronjob

### DIFF
--- a/connectors/config.py
+++ b/connectors/config.py
@@ -1,5 +1,14 @@
 import os
 
+
+def _is_true(env_var):
+    return str(os.getenv(env_var, "false")).lower() in [
+        "1",
+        "t",
+        "true",
+    ]
+
+
 LOG_LEVEL_GLOBAL = os.getenv("LOG_LEVEL", "INFO").upper()
 LOG_LEVEL_APP = os.getenv("LOG_LEVEL", "DEBUG").upper()
 
@@ -32,6 +41,8 @@ EMBED_QUERY_PREFIX = os.getenv("EMBED_QUERY_PREFIX", "search_query")
 EMBED_DOCUMENT_PREFIX = os.getenv("EMBED_DOCUMENT_PREFIX", "")
 
 S3_SYNC_CONFIG_FILE = os.getenv("S3_SYNC_CONFIG_FILE", "s3.yaml")
+S3_SYNC_EXPORT_METRICS = _is_true("S3_SYNC_EXPORT_METRICS")
+S3_SYNC_EXPORT_METRICS_SLEEP_SECS = int(os.getenv("S3_SYNC_EXPORT_METRICS_SLEEP_SECS", 60))
 
 METRICS_PREFIX = os.getenv("METRICS_PREFIX", "tangerine")
 

--- a/openshift/backend.template.yaml
+++ b/openshift/backend.template.yaml
@@ -146,7 +146,8 @@ objects:
               capabilities: {}
               privileged: false
             ports:
-              - containerPort: 8000
+              - name: tangerine-backend
+                containerPort: 8000
                 protocol: TCP
             imagePullPolicy: IfNotPresent
             terminationMessagePolicy: File

--- a/openshift/s3sync-cronjob.template.yaml
+++ b/openshift/s3sync-cronjob.template.yaml
@@ -76,6 +76,8 @@ objects:
   apiVersion: batch/v1
   metadata:
     name: tangerine-s3-sync
+    labels:
+      app.kubernetes.io/name: tangerine-backend-s3sync
   spec:
     suspend: ${{S3_SYNC_SUSPEND}}
     schedule: "*/30 * * * *"
@@ -84,6 +86,9 @@ objects:
     jobTemplate:
       spec:
         template:
+          metadata:
+            labels:
+              app.kubernetes.io/name: tangerine-backend-s3sync
           spec:
             volumes:
               - name: s3sync-config
@@ -102,6 +107,10 @@ objects:
                   limits:
                     memory: ${MEMORY_LIMIT}
                     cpu: ${CPU_LIMIT}
+                ports:
+                  - name: tangerine-backend
+                    containerPort: 8000
+                    protocol: TCP
                 env:
                   - name: S3_SYNC_EXPORT_METRICS
                     value: ${S3_SYNC_EXPORT_METRICS}

--- a/openshift/s3sync-cronjob.template.yaml
+++ b/openshift/s3sync-cronjob.template.yaml
@@ -29,6 +29,10 @@ parameters:
     value: latest
   - name: FORCE_RESYNC_UNTIL
     value: '0001-01-01T00:00:00Z'  # default is "the start of time", it will never run
+  - name: S3_SYNC_EXPORT_METRICS
+    value: "true"
+  - name: S3_SYNC_EXPORT_METRICS_SLEEP_SECS
+    value: "120"
 
 objects:
 - kind: Secret
@@ -99,6 +103,10 @@ objects:
                     memory: ${MEMORY_LIMIT}
                     cpu: ${CPU_LIMIT}
                 env:
+                  - name: S3_SYNC_EXPORT_METRICS
+                    value: ${S3_SYNC_EXPORT_METRICS}
+                  - name: S3_SYNC_EXPORT_METRICS_SLEEP_SECS
+                    value: ${S3_SYNC_EXPORT_METRICS_SLEEP_SECS}
                   - name: S3_SYNC_CONFIG_FILE
                     value: /s3sync-config/s3.yaml
                   - name: AWS_ACCESS_KEY_ID

--- a/openshift/s3sync-cronjob.template.yaml
+++ b/openshift/s3sync-cronjob.template.yaml
@@ -109,6 +109,8 @@ objects:
                     value: ${S3_SYNC_EXPORT_METRICS_SLEEP_SECS}
                   - name: S3_SYNC_CONFIG_FILE
                     value: /s3sync-config/s3.yaml
+                  - name: METRICS_PREFIX
+                    value: "tangerine_s3sync"
                   - name: AWS_ACCESS_KEY_ID
                     valueFrom:
                       secretKeyRef:


### PR DESCRIPTION
Enables the HTTP server for `/metrics` to be started if `flask s3sync` is invoked with `S3_SYNC_METRICS_ENABLED`.

This allows prometheus to collect embedding token usage metrics from the s3sync CronJob pods.

Sometimes the sync can completely quickly, and prometheus may not have a chance to scrape metrics before the pod dies. So when the sync is done, the job will sleep for a time determined by `S3_SYNC_METRICS_SLEEP_SECS` to give prometheus more time to scrape from `/metrics`