### PR TITLE
Get hybrid search working, add search engine score calculations, other fixes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,8 +119,8 @@ services:
       - ENABLE_RERANKING=false
       - ENABLE_QUALITY_DETECTION=false
       - ENABLE_HYBRID_SEARCH=true
-      - ENABLE_MMR_SEARCH=false
-      - ENABLE_SIMILARITY_SEARCH=false
+      - ENABLE_MMR_SEARCH=true
+      - ENABLE_SIMILARITY_SEARCH=true
       - ENABLE_FULL_TEXT_SEARCH=false
       - LOG_LEVEL_APP=debug
       - DEBUG_VERBOSE=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,8 +119,8 @@ services:
       - ENABLE_RERANKING=false
       - ENABLE_QUALITY_DETECTION=false
       - ENABLE_HYBRID_SEARCH=true
-      - ENABLE_MMR_SEARCH=true
-      - ENABLE_SIMILARITY_SEARCH=true
+      - ENABLE_MMR_SEARCH=false
+      - ENABLE_SIMILARITY_SEARCH=false
       - ENABLE_FULL_TEXT_SEARCH=false
       - LOG_LEVEL_APP=debug
       - DEBUG_VERBOSE=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,7 +114,7 @@ services:
       - LLM_MODEL_NAME=mistral
       - EMBED_MODEL_NAME=nomic-embed-text
       - EMBED_QUERY_PREFIX=search_query
-      - EMBED_DOCUMENT_PREFIX=
+      - EMBED_DOCUMENT_PREFIX=search_document
       - STORE_INTERACTIONS=true
       - ENABLE_RERANKING=false
       - ENABLE_QUALITY_DETECTION=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,7 +114,7 @@ services:
       - LLM_MODEL_NAME=mistral
       - EMBED_MODEL_NAME=nomic-embed-text
       - EMBED_QUERY_PREFIX=search_query
-      - EMBED_DOCUMENT_PREFIX=search_document
+      - EMBED_DOCUMENT_PREFIX=
       - STORE_INTERACTIONS=true
       - ENABLE_RERANKING=false
       - ENABLE_QUALITY_DETECTION=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,8 +113,8 @@ services:
       #- EMBED_BASE_URL=http://tangerine-text-embeddings-inference:8001/v1
       - LLM_MODEL_NAME=mistral
       - EMBED_MODEL_NAME=nomic-embed-text
-      - EMBED_QUERY_PREFIX="search_query"
-      - EMBED_DOCUMENT_PREFIX="search_document"
+      - EMBED_QUERY_PREFIX=search_query
+      - EMBED_DOCUMENT_PREFIX=search_document
       - STORE_INTERACTIONS=true
       - ENABLE_RERANKING=false
       - ENABLE_QUALITY_DETECTION=false

--- a/src/tangerine/config.py
+++ b/src/tangerine/config.py
@@ -48,9 +48,9 @@ EMBED_MODEL_NAME = os.getenv("EMBED_MODEL_NAME", "nomic-embed-text")
 # for snowflake-arctic-embed-m-long: 'Represent this sentence for searching relevant passages'
 EMBED_QUERY_PREFIX = os.getenv("EMBED_QUERY_PREFIX", "search_query")
 
-# for nomic: 'search_document' or ''
+# for nomic: 'search_document'
 # for snowflake-arctic-embed-m-long: ''
-EMBED_DOCUMENT_PREFIX = os.getenv("EMBED_DOCUMENT_PREFIX", "")
+EMBED_DOCUMENT_PREFIX = os.getenv("EMBED_DOCUMENT_PREFIX", "search_document")
 
 S3_SYNC_CONFIG_FILE = os.getenv("S3_SYNC_CONFIG_FILE", "s3.yaml")
 S3_SYNC_POOL_SIZE = int(os.getenv("S3_SYNC_POOL_SIZE", 15))

--- a/src/tangerine/config.py
+++ b/src/tangerine/config.py
@@ -48,7 +48,7 @@ EMBED_MODEL_NAME = os.getenv("EMBED_MODEL_NAME", "nomic-embed-text")
 # for snowflake-arctic-embed-m-long: 'Represent this sentence for searching relevant passages'
 EMBED_QUERY_PREFIX = os.getenv("EMBED_QUERY_PREFIX", "search_query")
 
-# for nomic: 'search_document'
+# for nomic: 'search_document' or ''
 # for snowflake-arctic-embed-m-long: ''
 EMBED_DOCUMENT_PREFIX = os.getenv("EMBED_DOCUMENT_PREFIX", "")
 

--- a/src/tangerine/search.py
+++ b/src/tangerine/search.py
@@ -53,7 +53,10 @@ class SearchProvider(ABC):
         min_score = min(r.score for r in results)
         for r in results:
             # normalize score to 0-1
-            r.score = (r.score - min_score) / (max_score - min_score)
+            if max_score == min_score:
+                r.score = 1.0
+            else:
+                r.score = (r.score - min_score) / (max_score - min_score)
             # scale by this search provider's scaling factor
             r.score = r.score * self.SCORE_SCALING_FACTOR
             # update metadata
@@ -80,6 +83,7 @@ class FTSPostgresSearchProvider(SearchProvider):
 
     RETRIEVAL_METHOD = "fts_postgres"
     QUERY_FILE = "fts_tsvector.sql"
+    SCORE_SCALING_FACTOR = 2.0
 
     def __init__(self):
         super().__init__()
@@ -153,10 +157,11 @@ class SimilaritySearchProvider(SearchProvider):
 
 
 class HybridSearchProvider(SearchProvider):
-    """Hybrid Search combining Vector Similarity and Full-Text BM25 Search in PGVector."""
+    """Hybrid Search combining Vector Similarity and Full-Text Search."""
 
     RETRIEVAL_METHOD = "hybrid"
     QUERY_FILE = "hybrid_search.sql"
+    SCORE_SCALING_FACTOR = 5.0
 
     def __init__(self):
         super().__init__()

--- a/src/tangerine/search.py
+++ b/src/tangerine/search.py
@@ -111,7 +111,7 @@ class FTSPostgresSearchProvider(SearchProvider):
 
         for idx, row in enumerate(results):
             score = row.score
-            doc = Document(page_content=row.document, metadata=row.cmetadata)
+            doc = Document(id=row.id, page_content=row.document, metadata=row.cmetadata)
             search_results.append(SearchResult(document=doc, score=score, rank=idx))
 
         return super()._process_results(search_results)
@@ -219,7 +219,7 @@ class HybridSearchProvider(SearchProvider):
             # Process results into LangChain's SearchResult format
             search_results = []
             for idx, row in enumerate(results):
-                doc = Document(page_content=row.document, metadata=row.cmetadata)
+                doc = Document(id=row.id, page_content=row.document, metadata=row.cmetadata)
                 score = row.rrf_score
                 search_results.append(SearchResult(document=doc, score=score, rank=idx))
 
@@ -307,6 +307,8 @@ class SearchEngine:
         aggregated_results = {}
         for r in results:
             document_id = r.document.id
+            if not document_id:
+                raise ValueError("document id cannot be 'None'")
             if document_id not in aggregated_results:
                 aggregated_results[document_id] = SearchResult(document=r.document, score=0)
             aggregated_results[document_id].rrf_score += 1 / (1 + r.rank)

--- a/src/tangerine/search.py
+++ b/src/tangerine/search.py
@@ -277,6 +277,7 @@ class SearchEngine:
             # no need to aggregate, just return as-is
             return sorted(results, key=lambda r: r.score, reverse=True)
 
+        # TODO: incorporate weighted RRF here depending on provider?
         aggregated_results = {}
         for r in results:
             document_id = r.document.id
@@ -297,6 +298,8 @@ class SearchEngine:
 
         for provider in self.search_providers:
             results.extend(provider.search(agent_id, query, embedding))
+
+        sorted_results = []
 
         # Rank the results using LLM if enabled, otherwise by score
         if cfg.ENABLE_RERANKING:

--- a/src/tangerine/search.py
+++ b/src/tangerine/search.py
@@ -300,7 +300,8 @@ class SearchEngine:
             log.debug("sorting results by score")
             sorted_results = sorted(deduped_results, key=lambda r: r.score, reverse=True)
 
-        return sorted_results
+        # return only top 4 results
+        return sorted_results[:4]
 
 
 search_engine = SearchEngine()

--- a/src/tangerine/sql/fts_tsvector.sql
+++ b/src/tangerine/sql/fts_tsvector.sql
@@ -2,13 +2,13 @@ SELECT
     id,
     document,
     cmetadata,
-    ts_rank_cd(fts_vector, plainto_tsquery('english', :q)) AS score
+    ts_rank_cd(fts_vector, plainto_tsquery('english', :query)) AS score
 FROM
     langchain_pg_embedding
 WHERE
     cmetadata->>'agent_id' = :agent_id
     AND cmetadata->>'active' = 'True'
-    AND fts_vector @@ plainto_tsquery('english', :q)
+    AND fts_vector @@ plainto_tsquery('english', :query)
 ORDER BY
     score DESC
 LIMIT 4;

--- a/src/tangerine/sql/fts_tsvector.sql
+++ b/src/tangerine/sql/fts_tsvector.sql
@@ -1,5 +1,14 @@
-SELECT id, document, cmetadata, ts_rank_cd(fts_vector, plainto_tsquery('english', :q)) AS score
-FROM langchain_pg_embedding
-WHERE cmetadata->>'agent_id' = :agent_id AND cmetadata->>'active' = 'True' AND fts_vector @@ plainto_tsquery('english', :q)
-ORDER BY score DESC
+SELECT
+    id,
+    document,
+    cmetadata,
+    ts_rank_cd(fts_vector, plainto_tsquery('english', :q)) AS score
+FROM
+    langchain_pg_embedding
+WHERE
+    cmetadata->>'agent_id' = :agent_id
+    AND cmetadata->>'active' = 'True'
+    AND fts_vector @@ plainto_tsquery('english', :q)
+ORDER BY
+    score DESC
 LIMIT 4;

--- a/src/tangerine/sql/fts_tsvector.sql
+++ b/src/tangerine/sql/fts_tsvector.sql
@@ -1,5 +1,5 @@
-SELECT id, document, cmetadata, ts_rank_cd(fts_vector, plainto_tsquery('english', :q)) AS rank
+SELECT id, document, cmetadata, ts_rank_cd(fts_vector, plainto_tsquery('english', :q)) AS score
 FROM langchain_pg_embedding
 WHERE cmetadata->>'agent_id' = :agent_id AND cmetadata->>'active' = 'True' AND fts_vector @@ plainto_tsquery('english', :q)
-ORDER BY rank DESC
+ORDER BY score DESC
 LIMIT 4;

--- a/src/tangerine/sql/hybrid_search.sql
+++ b/src/tangerine/sql/hybrid_search.sql
@@ -3,36 +3,39 @@ WITH fts_results AS (
         id,
         document,
         cmetadata,
-        ts_rank_cd(fts_vector, plainto_tsquery('english', :query)) AS fts_rank
+        RANK () OVER (ORDER BY ts_rank_cd(fts_vector, plainto_tsquery('english', :query)) DESC) as rank
     FROM
         langchain_pg_embedding
     WHERE
         cmetadata->>'agent_id' = :agent_id AND cmetadata->>'active' = 'True' AND fts_vector @@ plainto_tsquery('english', :query)
+    ORDER BY
+      ts_rank_cd(fts_vector, plainto_tsquery('english', :query)) DESC
+    LIMIT 20
 ),
 vector_results AS (
     SELECT
         id,
         document,
         cmetadata,
-        -(embedding <#> :embedding) AS vector_rank
+        RANK () OVER (ORDER BY -(embedding <#> :embedding) DESC) as rank
     FROM
         langchain_pg_embedding
     WHERE
         cmetadata->>'agent_id' = :agent_id AND cmetadata->>'active' = 'True'
     ORDER BY
-        vector_rank DESC
-    LIMIT 100  -- Limit the number of candidates to refine the query performance
+        ORDER BY -(embedding <#> :embedding) DESC
+    LIMIT 20
 )
 SELECT
-    fts_results.id,
-    fts_results.document,
-    fts_results.cmetadata,
-    (1 / (1 + fts_results.fts_rank)) + (1 / (1 + vector_results.vector_rank)) AS rrf_score
+    COALESCE(fts_results.id, vector_results.id) AS id,
+    COALESCE(fts_results.document, vector_results.document) AS document,
+    COALESCE(fts_results.cmetadata, vector_results.cmetadata) AS cmetadata,
+    COALESCE(1 / (50 + fts_results.rank), 0.0) + COALESCE(1 / (50 + vector_results.rank), 0.0) AS rrf_score -- k = 50
 FROM
     fts_results
-JOIN
+FULL OUTER JOIN
     vector_results
     ON fts_results.id = vector_results.id
 ORDER BY
     rrf_score DESC
-LIMIT 4;
+LIMIT 5;

--- a/src/tangerine/sql/hybrid_search.sql
+++ b/src/tangerine/sql/hybrid_search.sql
@@ -3,13 +3,15 @@ WITH fts_results AS (
         id,
         document,
         cmetadata,
-        RANK () OVER (ORDER BY ts_rank_cd(fts_vector, plainto_tsquery('english', :query)) DESC) as rank
+        RANK() OVER (ORDER BY ts_rank_cd(fts_vector, plainto_tsquery('english', :query)) DESC) AS rank
     FROM
         langchain_pg_embedding
     WHERE
-        cmetadata->>'agent_id' = :agent_id AND cmetadata->>'active' = 'True' AND fts_vector @@ plainto_tsquery('english', :query)
+        cmetadata->>'agent_id' = :agent_id
+        AND cmetadata->>'active' = 'True'
+        AND fts_vector @@ plainto_tsquery('english', :query)
     ORDER BY
-      ts_rank_cd(fts_vector, plainto_tsquery('english', :query)) DESC
+        ts_rank_cd(fts_vector, plainto_tsquery('english', :query)) DESC
     LIMIT 20
 ),
 vector_results AS (
@@ -17,20 +19,21 @@ vector_results AS (
         id,
         document,
         cmetadata,
-        RANK () OVER (ORDER BY -(embedding <#> :embedding) DESC) as rank
+        RANK() OVER (ORDER BY -(embedding <#> :embedding) DESC) AS rank
     FROM
         langchain_pg_embedding
     WHERE
-        cmetadata->>'agent_id' = :agent_id AND cmetadata->>'active' = 'True'
+        cmetadata->>'agent_id' = :agent_id
+        AND cmetadata->>'active' = 'True'
     ORDER BY
-        ORDER BY -(embedding <#> :embedding) DESC
+        -(embedding <#> :embedding) DESC
     LIMIT 20
 )
 SELECT
     COALESCE(fts_results.id, vector_results.id) AS id,
     COALESCE(fts_results.document, vector_results.document) AS document,
     COALESCE(fts_results.cmetadata, vector_results.cmetadata) AS cmetadata,
-    COALESCE(1 / (50 + fts_results.rank), 0.0) + COALESCE(1 / (50 + vector_results.rank), 0.0) AS rrf_score -- k = 50
+    COALESCE(1 / (50 + fts_results.rank) * 0.7, 0.0) + COALESCE(1 / (50 + vector_results.rank) * 0.3, 0.0) AS rrf_score -- k = 50, weighting fts results higher
 FROM
     fts_results
 FULL OUTER JOIN

--- a/src/tangerine/sql/hybrid_search.sql
+++ b/src/tangerine/sql/hybrid_search.sql
@@ -21,16 +21,16 @@ vector_results AS (
         cmetadata->>'agent_id' = :agent_id AND cmetadata->>'active' = 'True'
     ORDER BY
         vector_rank DESC
-    LIMIT 100  -- Limit the number of candidates to refine the query performance
+    LIMIT 20
 )
 SELECT
-    fts_results.id,
-    fts_results.document,
-    fts_results.cmetadata,
-    (1 / (1 + fts_results.fts_rank)) + (1 / (1 + vector_results.vector_rank)) AS rrf_score
+    COALESCE(fts_results.id, vector_results.id) AS id,
+    COALESCE(fts_results.document, vector_results.document) AS document,
+    COALESCE(fts_results.cmetadata, vector_results.cmetadata) AS cmetadata,
+    (1 / (1 + COALESCE(fts_results.fts_rank, 0))) + (1 / (1 + COALESCE(vector_results.vector_rank, 0))) AS rrf_score
 FROM
     fts_results
-JOIN
+FULL OUTER JOIN
     vector_results
     ON fts_results.id = vector_results.id
 ORDER BY

--- a/src/tangerine/sql/hybrid_search.sql
+++ b/src/tangerine/sql/hybrid_search.sql
@@ -21,16 +21,16 @@ vector_results AS (
         cmetadata->>'agent_id' = :agent_id AND cmetadata->>'active' = 'True'
     ORDER BY
         vector_rank DESC
-    LIMIT 20
+    LIMIT 100  -- Limit the number of candidates to refine the query performance
 )
 SELECT
-    COALESCE(fts_results.id, vector_results.id) AS id,
-    COALESCE(fts_results.document, vector_results.document) AS document,
-    COALESCE(fts_results.cmetadata, vector_results.cmetadata) AS cmetadata,
-    (1 / (1 + COALESCE(fts_results.fts_rank, 0))) + (1 / (1 + COALESCE(vector_results.vector_rank, 0))) AS rrf_score
+    fts_results.id,
+    fts_results.document,
+    fts_results.cmetadata,
+    (1 / (1 + fts_results.fts_rank)) + (1 / (1 + vector_results.vector_rank)) AS rrf_score
 FROM
     fts_results
-FULL OUTER JOIN
+JOIN
     vector_results
     ON fts_results.id = vector_results.id
 ORDER BY

--- a/src/tangerine/vector.py
+++ b/src/tangerine/vector.py
@@ -77,7 +77,6 @@ class VectorStoreInterface:
 
     def split_to_document_chunks(self, text, metadata) -> list[Document]:
         """Split documents into chunks. Use markdown-aware splitter first if text is markdown."""
-
         text_splitter = RecursiveCharacterTextSplitter(
             chunk_size=self.splitter_chunk_size,
             chunk_overlap=self.chunk_overlap,
@@ -97,6 +96,13 @@ class VectorStoreInterface:
         )
 
         if self.has_markdown_headers(text):
+            # find title if possible and add to metadata
+            for line in text.splitlines():
+                if line.startswith("# "):
+                    # we found a title header, add it to metadata
+                    metadata["title"] = line.lstrip("# ").strip()
+                    break
+
             markdown_documents = md_splitter.split_text(text)
             chunks = text_splitter.split_documents(markdown_documents)
             # convert back to list[str] so we can filter and combine them

--- a/src/tangerine/vector.py
+++ b/src/tangerine/vector.py
@@ -126,12 +126,7 @@ class VectorStoreInterface:
         if len_diff:
             log.debug("dropped %d empty chunks", len_diff)
 
-        # Convert back to Document objects for call to 'embed_documents'
-        documents = []
-        for chunk in chunks:
-            if cfg.EMBED_DOCUMENT_PREFIX:
-                chunk = f"{cfg.EMBED_DOCUMENT_PREFIX}: {chunk}"
-            documents.append(Document(page_content=chunk, metadata=metadata))
+        documents = [Document(page_content=chunk, metadata=metadata) for chunk in chunks]
 
         return documents
 
@@ -185,11 +180,23 @@ class VectorStoreInterface:
                 size,
             )
             try:
-                self.store.add_documents(batch)
+                if cfg.EMBED_DOCUMENT_PREFIX:
+                    embeddings = self._embeddings.embed_documents(
+                        [f"{cfg.EMBED_DOCUMENT_PREFIX}: {d.page_content}" for d in batch]
+                    )
+                else:
+                    embeddings = self._embeddings.embed_documents([d.page_content for d in batch])
+
+                self.store.add_embeddings(
+                    texts=[d.page_content for d in batch],
+                    embeddings=list(embeddings),
+                    metadatas=[d.metadata for d in batch],
+                )
             except Exception:
                 log.exception(
                     "error on batch %d/%d for file %s", current_batch, total_batches, file
                 )
+                continue
 
     def _build_metadata_filter(self, metadata):
         filter_stmts = []


### PR DESCRIPTION
Get hybrid search properly working:
* Use inverse of embedding score in for ranking vector results in hybrid search since `<#>` returns a [negative inner product](https://github.com/pgvector/pgvector?tab=readme-ov-file#querying)
* Improve the SQL query to rank vector score and FTS score and then use RRF to compile a final score for each document chunk (`::numeric` was essential to getting this working, otherwise the calculation was always returning `0.0`)

Other search related improvements:
* Have each SearchProvider rank its results and use RRF to aggregate at the end
* Normalize scores for all SearchProviders results (though we don't really use them now that we use rank and RRF...)

A bit unrelated, but while I was at it ...
* Bring back the title metadata that accidentally disappeared
* Separate embedding call to support embedding model instructions
