### PR TITLE
Standard response metadata bugfix, refactor responses

### DIFF
--- a/tests/test_chat_api.py
+++ b/tests/test_chat_api.py
@@ -20,7 +20,7 @@ def assistant_chat_api():
     api_instance._call_llm = MagicMock()
     api_instance._is_streaming_response = MagicMock()
     api_instance._handle_streaming_response = MagicMock()
-    api_instance._handle_final_response = MagicMock()
+    api_instance._handle_standard_response = MagicMock()
     api_instance._log_interaction = MagicMock()
     api_instance._interaction_storage_enabled = MagicMock()
 
@@ -48,8 +48,13 @@ def test_post_chat_non_streaming(assistant_chat_api):
     mock_search_results = [
         Document(page_content="AI is artificial intelligence", metadata={"source": "wiki"})
     ]
+    mock_search_metadata = [{"doc1": "some metadata"}]
     mock_embedding = [0.1, 0.2, 0.3]
-    mock_llm_response = "AI is the simulation of human intelligence."
+    mock_llm_response = MagicMock()  # Mock a streaming generator
+    mock_llm_response.__iter__.return_value = iter(
+        ["AI is ", "the simulation ", "of human", " intelligence."]
+    )
+    expected_response = "AI is the simulation of human intelligence."
     mock_interaction_id = "interaction-1234"
     mock_client = "client"
 
@@ -65,16 +70,19 @@ def test_post_chat_non_streaming(assistant_chat_api):
     )
     assistant_chat_api._embed_question.return_value = mock_embedding
     assistant_chat_api._get_search_results.return_value = mock_search_results
-    assistant_chat_api._call_llm.return_value = mock_llm_response
+    assistant_chat_api._call_llm.return_value = mock_llm_response, mock_search_metadata
     assistant_chat_api._is_streaming_response.return_value = False
-    assistant_chat_api._handle_final_response.return_value = {"response": mock_llm_response}, 200
+    assistant_chat_api._handle_standard_response.return_value = (
+        {"response": expected_response, "search_metadata": mock_search_metadata},
+        200,
+    )
     assistant_chat_api._interaction_storage_enabled.return_value = True
 
     response, status_code = assistant_chat_api.post(1)
 
     # Assertions
     assert status_code == 200
-    assert response == {"response": mock_llm_response}
+    assert response == {"response": expected_response, "search_metadata": mock_search_metadata}
 
     # Ensure all expected functions were called
     assistant_chat_api._get_assistant.assert_called_once_with(1)
@@ -85,11 +93,11 @@ def test_post_chat_non_streaming(assistant_chat_api):
         mock_previous_messages,
         mock_query,
         mock_search_results,
-        False,
         mock_interaction_id,
     )
-    assistant_chat_api._handle_final_response.assert_called_once_with(
+    assistant_chat_api._handle_standard_response.assert_called_once_with(
         mock_llm_response,
+        mock_search_metadata,
         mock_query,
         mock_embedding,
         mock_search_results,
@@ -109,9 +117,10 @@ def test_post_chat_streaming(assistant_chat_api):
     mock_search_results = [
         Document(page_content="AI is artificial intelligence", metadata={"source": "wiki"})
     ]
+    mock_search_metadata = [{"doc1": "some metadata"}]
     mock_embedding = [0.1, 0.2, 0.3]
     mock_llm_response = MagicMock()  # Mock a streaming generator
-    mock_llm_response.__iter__.return_value = iter(["data: AI is", "data: an intelligence"])
+    mock_llm_response.__iter__.return_value = iter(["AI is", " an intelligence"])
     mock_interaction_id = "interaction-1234"
     mock_client = "client"
 
@@ -127,7 +136,7 @@ def test_post_chat_streaming(assistant_chat_api):
     )
     assistant_chat_api._embed_question.return_value = mock_embedding
     assistant_chat_api._get_search_results.return_value = mock_search_results
-    assistant_chat_api._call_llm.return_value = mock_llm_response
+    assistant_chat_api._call_llm.return_value = mock_llm_response, mock_search_metadata
     assistant_chat_api._is_streaming_response.return_value = True
     assistant_chat_api._handle_streaming_response.return_value = "mock_stream_response"
     assistant_chat_api._interaction_storage_enabled.return_value = True
@@ -146,11 +155,11 @@ def test_post_chat_streaming(assistant_chat_api):
         mock_previous_messages,
         mock_query,
         mock_search_results,
-        True,
         mock_interaction_id,
     )
     assistant_chat_api._handle_streaming_response.assert_called_once_with(
         mock_llm_response,
+        mock_search_metadata,
         mock_query,
         mock_embedding,
         mock_search_results,


### PR DESCRIPTION
A team noticed that 'search_metadata' was no longer being returned in a non-streaming response. A bug was introduced earlier when we extracted text content.

I refactored this so that llm.ask always returns a generator (for the LLM response text) and a dict of search metadata. It is now up to the API handler to process/format that info however it wants to.