### PR TITLE
Standardize on SearchResult throughout the code

### DIFF
--- a/src/tangerine/llm.py
+++ b/src/tangerine/llm.py
@@ -1,12 +1,15 @@
 import logging
 import time
-from typing import Generator
+from typing import Generator, TYPE_CHECKING
 
 from langchain_community.callbacks.manager import get_openai_callback
 from langchain_community.callbacks.openai_info import OpenAICallbackHandler
 from langchain_core.documents import Document
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_openai import ChatOpenAI
+
+if TYPE_CHECKING:
+    from tangerine.search import SearchResult
 
 import tangerine.config as cfg
 from tangerine.agents.jira_agent import JiraAgent
@@ -72,13 +75,13 @@ def _record_metrics(
     llm_completion_rate.set(completion_rate)
 
 
-def _build_context(search_results: list[Document], content_char_limit: int = 0):
+def _build_context(search_results: list["SearchResult"], content_char_limit: int = 0):
     search_metadata = []
     context = ""
     log.debug("given %d search results as context", len(search_results))
-    for i, doc in enumerate(search_results):
-        page_content = doc.document.page_content
-        metadata = doc.document.metadata
+    for i, result in enumerate(search_results):
+        page_content = result.document.page_content
+        metadata = result.document.metadata
         search_metadata.append(
             {
                 "metadata": metadata,
@@ -160,7 +163,7 @@ def ask(
     assistants: list[Assistant],
     previous_messages,
     question,
-    search_results: list[Document],
+    search_results: list["SearchResult"],
     interaction_id=None,
     prompt: str | None = None,
     model: str | None = None,

--- a/src/tangerine/resources/assistant.py
+++ b/src/tangerine/resources/assistant.py
@@ -501,7 +501,7 @@ class AssistantAdvancedChatApi(AssistantChatApi):
 
     def _convert_chunk_array_to_documents(self, chunks):
         """
-        Converts an array of chunks into a list of Document objects.
+        Converts an array of chunks into a list of SearchResult objects.
         """
         return [
             SearchResult(document=Document(page_content=chunk, metadata={}), score=1)
@@ -563,13 +563,11 @@ class AssistantAdvancedChatApi(AssistantChatApi):
         if chunks:
             chunks = self._convert_chunk_array_to_documents(request.json.get("chunks"))
         search_results = chunks or search_engine.search(assistant_ids, question, embedding)
-        # Convert SearchResult objects to Document objects for llm.ask()
-        documents = [result.document for result in search_results]
         llm_response, search_metadata = llm.ask(
             assistants,
             previous_messages,
             question,
-            documents,
+            search_results,
             interaction_id=interaction_id,
             prompt=system_prompt,
             model=model_name,


### PR DESCRIPTION
We had places where code was expecting langchain Document objects, and other places that expected our SearchResult object. This could cause bugs in corner cases. I decided to standardize on SearchResult because it keeps our metadata present and standard through the entire code base.