### PR TITLE
Fix kb associate in s3sync

### DIFF
--- a/src/tangerine/sync/s3.py
+++ b/src/tangerine/sync/s3.py
@@ -472,7 +472,7 @@ def run(resync: bool = False) -> int:
         for kb_name in knowledgebase_names:
             knowledgebase = KnowledgeBase.get_by_name(kb_name)
             if knowledgebase:
-                assistant.associate_knowledgebase(knowledgebase.id)
+                assistant.associate_knowledgebase(knowledgebase)
                 log.info(
                     "associated knowledgebase '%s' with assistant '%s'", kb_name, assistant.name
                 )


### PR DESCRIPTION
The problem is in line 475 where assistant.associate_knowledgebase(knowledgebase.id) is being called with knowledgebase.id (an integer), but the SQLAlchemy relationship is expecting a KnowledgeBase object instance, not just the ID.


Assisted-by: claude v1.0.85